### PR TITLE
make sure that Zend logger is actually registered

### DIFF
--- a/src/XSD2PHP/src/com/mikebevz/xsd2php/Php2Xml.php
+++ b/src/XSD2PHP/src/com/mikebevz/xsd2php/Php2Xml.php
@@ -64,7 +64,8 @@ class Php2Xml extends Common
         }
 
         // @todo implement logger injection
-        if (class_exists('\Zend_Registry')) { // this does not work due to PHP bug @see http://bugs.php.net/bug.php?id=46813
+        // this does not work due to PHP bug @see http://bugs.php.net/bug.php?id=46813
+        if (class_exists('\Zend_Registry') && \Zend_Registry::isRegistered('logger')) {
             $this->logger = \Zend_Registry::get('logger');
         } else {
             $this->logger = new NullLogger();


### PR DESCRIPTION
In Zend FW, if `logger` is not registered, this would throw an exception. Added a check to use Zend logger only if it is actually present