### PR TITLE
Remove references to OAUTH constants

### DIFF
--- a/src/Core/HttpClients/SyncRestHandler.php
+++ b/src/Core/HttpClients/SyncRestHandler.php
@@ -164,9 +164,9 @@ class SyncRestHandler extends RestHandler
 
         //Check for the HTTP method
         if ('POST'==$requestParameters->HttpVerbType) {
-            $HttpMethod = OAUTH_HTTP_METHOD_POST;
+            $HttpMethod = 'POST';
         } elseif ('GET'==$requestParameters->HttpVerbType) {
-            $HttpMethod = OAUTH_HTTP_METHOD_GET;
+            $HttpMethod = 'GET';
         }else{
             throw new \Exception("THe HTTP verb is not supported.");
         }

--- a/src/Security/OAuthRequestValidator.php
+++ b/src/Security/OAuthRequestValidator.php
@@ -72,6 +72,6 @@ class OAuthRequestValidator extends RequestValidator
         $this->AccessTokenSecret = $accessTokenSecret;
         $this->ConsumerKey = $consumerKey;
         $this->ConsumerSecret = $consumerSecret;
-        $this->oauthSignatureMethod = OAUTH_SIG_METHOD_HMACSHA1;
+        $this->oauthSignatureMethod = 'HMAC-SHA1';
     }
 }


### PR DESCRIPTION
Remove references to OAUTH constants which causes an error when PHP oauth extension is not loaded