### PR TITLE
Add error element to faulthandler

### DIFF
--- a/src/Core/HttpClients/FaultHandler.php
+++ b/src/Core/HttpClients/FaultHandler.php
@@ -36,6 +36,8 @@ class FaultHandler
 
      private $intuitErrorCode;
 
+     private $intuitErrorElement;
+
      private $intuitErrorMessage;
 
      private $intuitErrorDetail;
@@ -103,6 +105,10 @@ class FaultHandler
         return $this->intuitErrorCode;
     }
 
+    public function getIntuitErrorElement(){
+        return $this->intuitErrorElement;
+    }
+
     public function getIntuitErrorMessage(){
         return $this->intuitErrorMessage;
     }
@@ -131,6 +137,11 @@ class FaultHandler
       $code = (string)$xmlObj->Fault->Error->attributes()['code'];
       if(isset($code) && !empty($code)){
         $this->intuitErrorCode = $code;
+      }
+
+      $element = (string)$xmlObj->Fault->Error->attributes()['element'];
+      if(isset($element) && !empty($element)){
+        $this->intuitErrorElement = $element;
       }
 
       $message = (string)$xmlObj->Fault->Error->Message;


### PR DESCRIPTION
Currently, the fault handler does not retrieve and make available the element where the validation issue occurred. The element where the issue occurring is critical debugging information. 

`echo "The Intuit Helper message is: IntuitErrorType:{" . $error->getIntuitErrorType() . "} IntuitErrorCode:{" . $error->getIntuitErrorCode() . "} IntuitErrorElement:{" . $error-> getIntuitErrorElement() . "} IntuitErrorMessage:{" . $error->getIntuitErrorMessage() . "} IntuitErrorDetail:{" . $error->getIntuitErrorDetail() . "}";`
