### PR TITLE
Fix formatting of changedSince date in CDC requests

### DIFF
--- a/src/DataService/DataService.php
+++ b/src/DataService/DataService.php
@@ -888,7 +888,7 @@ class DataService
         $uri = null;
 
 
-        $formattedChangedSince = date("Y-m-d\TH:m:s", $this->verifyChangedSince($changedSince));
+        $formattedChangedSince = date("Y-m-d\TH:i:s", $this->verifyChangedSince($changedSince));
         $query = "entities=" . $entityString . "&changedSince=" . $formattedChangedSince;
         $uri = "company/{1}/cdc?{2}";
         //$uri = str_replace("{0}", CoreConstants::VERSION, $uri);


### PR DESCRIPTION
The $formattedChangedSince sent with the CDC request placed the month (m) in the place of the minute (i). 