### PR TITLE
Bug fix - protocol was being always forced to OAuth2.

### DIFF
--- a/src/DataService/DataService.php
+++ b/src/DataService/DataService.php
@@ -335,7 +335,7 @@ class DataService
 
             }
 
-            if($ServiceContext->IppConfiguration->OAuthMode = CoreConstants::OAUTH2)
+            if($ServiceContext->IppConfiguration->OAuthMode == CoreConstants::OAUTH2)
             {
                 $oauth2Config = $ServiceContext->IppConfiguration->Security;
                 if($oauth2Config instanceof OAuth2AccessToken){


### PR DESCRIPTION
This looks like a typo: 

`if($ServiceContext->IppConfiguration->OAuthMode = CoreConstants::OAUTH2)`

It's always SETTING the `OAuthMode` to `CoreConstants::OAUTH2` vs. comparing/checking against it (single `=` vs. double `==`). 