### PR TITLE
not parse response as xml for not-xml responses

### DIFF
--- a/src/Core/HttpClients/SyncRestHandler.php
+++ b/src/Core/HttpClients/SyncRestHandler.php
@@ -271,7 +271,7 @@ class SyncRestHandler extends RestHandler
      * @param Array $httpHeaders  The headers for the request
      */
     public function LogAPIResponseToLog($body, $requestUri, $httpHeaders){
-      if(strpos($httpHeaders[CoreConstants::CONTENT_TYPE], CoreConstants::CONTENTTYPE_APPLICATIONXML) === 0){
+      if(strpos($httpHeaders[CoreConstants::CONTENT_TYPE], CoreConstants::CONTENTTYPE_APPLICATIONXML) !== false){
              $body = $this->parseStringToDom($body);
       }
 

--- a/src/Core/HttpClients/SyncRestHandler.php
+++ b/src/Core/HttpClients/SyncRestHandler.php
@@ -271,7 +271,7 @@ class SyncRestHandler extends RestHandler
      * @param Array $httpHeaders  The headers for the request
      */
     public function LogAPIResponseToLog($body, $requestUri, $httpHeaders){
-      if(strpos($httpHeaders[CoreConstants::CONTENT_TYPE], CoreConstants::CONTENTTYPE_APPLICATIONXML) == 0){
+      if(strpos($httpHeaders[CoreConstants::CONTENT_TYPE], CoreConstants::CONTENTTYPE_APPLICATIONXML) === 0){
              $body = $this->parseStringToDom($body);
       }
 


### PR DESCRIPTION
If CONTENTTYPE_APPLICATIONXML was not found strpos() return FALSE