### PR TITLE
Fix related to faultHandler

### DIFF
--- a/src/DataService/Batch.php
+++ b/src/DataService/Batch.php
@@ -297,7 +297,7 @@ class Batch
 
             list($responseCode, $responseBody) = $restRequestHandler->sendRequest($requestParameters, $httpsPostBody, null);
             $faultHandler = $restRequestHandler->getFaultHandler();
-            if (isset($faultHandler)) {
+            if (!empty($faultHandler)) {
                 $this->lastError = $faultHandler;
                 return null;
             }


### PR DESCRIPTION
Checking **isset($faultHandler)** (Line:300)may fail if **$faultHandler** value is _false_ and in new version 4.0.1 _false_ is being set to faultHandler