### PR TITLE
Serialized/Deserialized BaseCurl and curl handle is no longer available.

### DIFF
--- a/src/Core/HttpClients/BaseCurl.php
+++ b/src/Core/HttpClients/BaseCurl.php
@@ -50,7 +50,7 @@ class BaseCurl{
    * @return True or False
    */
   public function isCurlSet(){
-      if(!isset($this->curl)) return false;
+      if(!isset($this->curl) || $this->curl === 0) return false;
       return true;
   }
 


### PR DESCRIPTION
Added checking if $this->curl === 0 for deserialized curl resource. If a curl resource, or an object containing a curl resource, is serialized and later deserialized, the curl resource will pass the isset() test, but the handle will no longer exist. If the curl resource handle is not available, the resource will return 0. Adding this test will help BaseCurl reset $this->curl as necessary. May want to consider renaming isCurlSet() to isCurlSetAndValid().