### PR TITLE
Fix for IntuitResponse.php

### DIFF
--- a/src/Core/HttpClients/IntuitResponse.php
+++ b/src/Core/HttpClients/IntuitResponse.php
@@ -152,7 +152,7 @@ class IntuitResponse{
         //A standard message for now.
         //TO DO: Wait V3 Team to provide different message for different response.
         $this->faultHandler->setHelpMsg("Invalid auth/bad request (got a " . $httpResponseCode . ", expected HTTP/1.1 20X or a redirect)");
-        if(isset($this->getResponseContentType) && strcasecmp($this->getResponseContentType, CoreConstants::CONTENTTYPE_APPLICATIONXML) == 0){
+        if(($this->getResponseContentType() != null) && (strcasecmp($this->getResponseContentType(), CoreConstants::CONTENTTYPE_APPLICATIONXML) == 0 || strcasecmp($this->getResponseContentType(), CoreConstants::CONTENTTYPE_TEXTXML) == 0)) {
             $this->faultHandler->parseResponse($body);
         }
      }else{


### PR DESCRIPTION
Calling FaultUnit->getIntuitErrorCode() when getting response error would always return 0, because the code attribute in Error element in XML response is not being parsed due to the comparison failed in method setFaultHandler. This is a fix for this issue where it is now calling the getter of the contentType correctly and cater for both application/xml and text/xml content type.