### PR TITLE
the Quickbooks API expects the class paramater to be named  'class' in…

### DIFF
--- a/src/ReportService/ReportService.php
+++ b/src/ReportService/ReportService.php
@@ -1070,7 +1070,7 @@ class ReportService
             array_push($uriParameterList, array("item", $this->getItem()));
         }
         if (!is_null($this->classid)) {
-            array_push($uriParameterList, array("classid", $this->getClassid()));
+            array_push($uriParameterList, array("class", $this->getClassid()));
         }
         if (!is_null($this->appaid)) {
             array_push($uriParameterList, array("appaid", $this->getAppaid()));


### PR DESCRIPTION
…stead of 'classid'