### PR TITLE
Updates all the PHP Objects to Minor Version 23

### DIFF
--- a/src/Data/IPPAPCreditCardOperationEnum.php
+++ b/src/Data/IPPAPCreditCardOperationEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPAPCreditCardOperationEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of Credit Card operation type: Charge or Credit.
+                Description: Enumeration of Credit Card
+                operation type: Charge or Credit.
 
  */
 class IPPAPCreditCardOperationEnum
@@ -23,22 +24,22 @@ class IPPAPCreditCardOperationEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAPCreditCardOperationEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAPCreditCardOperationEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAPCreditCardOperationEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAPCreditCardOperationEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPAPCreditCardOperationEnum

--- a/src/Data/IPPAccount.php
+++ b/src/Data/IPPAccount.php
@@ -6,8 +6,12 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType IntuitEntity
  * @xmlName IPPAccount
  * @var IPPAccount
- * @xmlDefinition Account is a component of a Chart Of Accounts, and is part of a Ledger.  Used to record a total monetary amount allocated against a specific use.
-                Accounts are one of five basic types: asset, liability, revenue (income), expenses, or equity.
+ * @xmlDefinition Account is a component of a Chart Of Accounts, and
+                is part of a Ledger. Used to record a total monetary amount
+                allocated against a specific use.
+                Accounts are one of five basic types: asset, liability, revenue (income),
+                expenses, or equity.
+
  */
 class IPPAccount extends IPPIntuitEntity
 {
@@ -21,20 +25,20 @@ class IPPAccount extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAccount', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAccount', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAccount', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAccount', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition User recognizable name for the Account.[br /]
                                 Product: ALL
@@ -52,8 +56,9 @@ class IPPAccount extends IPPIntuitEntity
     public $Name;
     /**
      * @Definition
-                            Product: ALL
-                            Description: Specifies the Account is a SubAccount or Not. True if subaccount, false or null if it is top-level account
+                                Product: ALL
+                                Description: Specifies the Account is a SubAccount or Not. True if
+                                subaccount, false or null if it is top-level account
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -65,7 +70,8 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Specifies the Parent AccountId if this represents a SubAccount. Else null or empty
+                                Description: Specifies the Parent AccountId if this
+                                represents a SubAccount. Else null or empty
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -77,7 +83,10 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: User entered description for the account, which may include user entered information to guide bookkeepers/accountants in deciding what journal entries to post to the account.
+                                Description: User entered
+                                description for the account, which may include user entered
+                                information to guide bookkeepers/accountants in deciding what
+                                journal entries to post to the account.
                                 ValidRange: QBW: Max=200
                                 ValidRange: QBO: Max=100
 
@@ -91,7 +100,10 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Fully qualified name of the entity. The fully qualified name prepends the topmost parent, followed by each sub element separated by colons. Takes the form of: [br /] Parent:Account1:SubAccount1:SubAccount2
+                                Description: Fully qualified name
+                                of the entity. The fully qualified name prepends the topmost
+                                parent, followed by each sub element separated by colons. Takes
+                                the form of: [br /] Parent:Account1:SubAccount1:SubAccount2
                                 InputType: ReadOnly
 
      * @xmlType element
@@ -104,7 +116,38 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Whether or not active inactive accounts may be hidden from most display purposes and may not be posted to.
+                                Description: Display Name of the
+                                account that will be shown in Transaction Forms based on Account
+                                Category
+                                ValidRange: QBO: Max=100
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName AccountAlias
+     * @var string
+     */
+    public $AccountAlias;
+    /**
+     * @Definition
+                                Product: ALL
+                                Description: Location Type for the
+                                Transaction.
+                                ValidRange: QBO: Max=50
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName TxnLocationType
+     * @var string
+     */
+    public $TxnLocationType;
+    /**
+     * @Definition
+                                Product: ALL
+                                Description: Whether or not active
+                                inactive accounts may be hidden from most display purposes and
+                                may not be posted to.
                                 Filterable: QBW
 
      * @xmlType element
@@ -117,7 +160,9 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: 5 types of classification an account classified.  Suggested examples of account type are Asset, Equity, Expense, Liability, Revenue
+                                Description: 5 types of
+                                classification an account classified. Suggested examples of
+                                account type are Asset, Equity, Expense, Liability, Revenue
                                 Filterable: QBW
 
      * @xmlType element
@@ -130,7 +175,9 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Type is a detailed account classification that specifies the use of this account. 16 type of account subtypes available in AccountTypeEnum
+                                Description: Type is a detailed
+                                account classification that specifies the use of this account.
+                                16 type of account subtypes available in AccountTypeEnum
                                 Filterable: QBW
                                 Required: ALL
 
@@ -144,7 +191,9 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: AccountSubTypeEnum specificies QBO on detail type. If not specified default value are listed for each SubType
+                                Description: AccountSubTypeEnum
+                                specificies QBO on detail type. If not specified default value
+                                are listed for each SubType
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -156,14 +205,14 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @br
      * @ul
-                                1000s: Assets
-                                2000s: Liabilities
-                                3000s: Equity
-                                4000s: Income
-                                5000s: Cost of Sales
-                                6000s, 7000s: Other operating expenses
-                                8000s: Other income
-                                9000s: Other expenses
+                                    1000s: Assets
+                                    2000s: Liabilities
+                                    3000s: Equity
+                                    4000s: Income
+                                    5000s: Cost of Sales
+                                    6000s, 7000s: Other operating expenses
+                                    8000s: Other income
+                                    9000s: Other expenses
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -172,36 +221,11 @@ class IPPAccount extends IPPIntuitEntity
      * @var string
      */
     public $AcctNum;
-
     /**
      * @Definition
                                 Product: QBO
-                                Description: A user friendly name for the account. It must be unique across all account categories. For France locales, only.
-
-     * @xmlType element
-     * @xmlNamespace http://schema.intuit.com/finance/v3
-     * @xmlMinOccurs 0
-     * @xmlName AccountAlias
-     * @var string
-     */
-    public $AccountAlias;
-
-    /**
-     * @Definition
-                                Product: QBO
-                                Description: The account location.  default is WithinFrance. For France locales, only.
-
-     * @xmlType element
-     * @xmlNamespace http://schema.intuit.com/finance/v3
-     * @xmlMinOccurs 0
-     * @xmlName TxnLocationType
-     * @var string
-     */
-    public $TxnLocationType;
-    /**
-     * @Definition
-                                Product: QBO
-                                Description: An extension to the base account number that can be added to Customer A/R or Supplier A/P accounts.
+                                Description: An extension to the base account number that can be added to
+                                Customer A/R or Supplier A/P accounts.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -213,7 +237,10 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: Bank Account Number, should include routing number whatever else depending upon the context, this may be the credit card number or the checking account number, etc.
+                                Description: Bank Account Number,
+                                should include routing number whatever else depending upon the
+                                context, this may be the credit card number or the checking
+                                account number, etc.
                                 ValidRange: QBW: max=25
 
      * @xmlType element
@@ -226,7 +253,8 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Specifies the Opening Balance amount when creating a new Balance Sheet account.
+                                Description: Specifies the Opening
+                                Balance amount when creating a new Balance Sheet account.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -238,7 +266,9 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Specifies the Date of the Opening Balance amount when creating a new Balance Sheet account.
+                                Description: Specifies the Date of
+                                the Opening Balance amount when creating a new Balance Sheet
+                                account.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -250,7 +280,9 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Specifies the balance amount for the current Account. Valid for Balance Sheet accounts.
+                                Description: Specifies the balance
+                                amount for the current Account. Valid for Balance Sheet
+                                accounts.
                                 InputType: QBW: ReadOnly
 
      * @xmlType element
@@ -263,7 +295,9 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Specifies the cumulative balance amount for the current Account and all its sub-accounts.
+                                Description: Specifies the
+                                cumulative balance amount for the current Account and all its
+                                sub-accounts.
                                 InputType: QBW: ReadOnly
 
      * @xmlType element
@@ -276,7 +310,8 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the Currency that this account will hold the amounts in.
+                                Description: Reference to the
+                                Currency that this account will hold the amounts in.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -288,7 +323,8 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Describes if the account is taxable
+                                Description: Describes if the
+                                account is taxable
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -300,8 +336,10 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: If the account is taxable, refers to taxcode reference if applicable
-                                I18n: QBW: GlobalOnly
+                                Description: If the account is
+                                taxable, refers to taxcode reference if applicable
+                                I18n: QBW:
+                                GlobalOnly
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -313,7 +351,12 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Indicates if the Account is linked with Online Banking feature (automatically download transactions) of QuickBooks Online or QuickBooks Desktop. Null or false indicates not linked with online banking. True if Online banking based download is enabled for this account.
+                                Description: Indicates if the
+                                Account is linked with Online Banking feature (automatically
+                                download transactions) of QuickBooks Online or QuickBooks
+                                Desktop. Null or false indicates not linked with online banking.
+                                True if Online banking based download is enabled for this
+                                account.
                                 InputType: ALL: ReadOnly
 
      * @xmlType element
@@ -326,7 +369,10 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Indicates the name of financial institution name if Account is linked with Online banking. Valid only if account is online banking enabled. This is optional and read-only.
+                                Description: Indicates the name of
+                                financial institution name if Account is linked with Online
+                                banking. Valid only if account is online banking enabled. This
+                                is optional and read-only.
                                 InputType: ALL: ReadOnly
 
      * @xmlType element
@@ -339,7 +385,8 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: The Journal Code that is associated with the account. This is required only for Bank accounts. This is applicable only in FR.
+                                Description: The Journal Code that is associated with the account. This is
+                                required only for Bank accounts. This is applicable only in FR.
                                 InputType: ALL: ReadOnly
 
      * @xmlType element
@@ -352,7 +399,8 @@ class IPPAccount extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: extension place holder for Account.
+                                Description: extension place holder
+                                for Account.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPAccountBasedExpenseLineDetail.php
+++ b/src/Data/IPPAccountBasedExpenseLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPAccountBasedExpenseLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: Account based expense detail for a transaction line.
+                Description: Account based expense
+                detail for a transaction line.
 
  */
 class IPPAccountBasedExpenseLineDetail
@@ -23,24 +24,25 @@ class IPPAccountBasedExpenseLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAccountBasedExpenseLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAccountBasedExpenseLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAccountBasedExpenseLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAccountBasedExpenseLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the Customer associated with the expense.
+                        Description: Reference to the
+                        Customer associated with the expense.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +54,8 @@ class IPPAccountBasedExpenseLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the Class associated with the expense.
+                        Description: Reference to the Class
+                        associated with the expense.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +67,8 @@ class IPPAccountBasedExpenseLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the Expense account associated with the service/non-sellable-item billing.
+                        Description: Reference to the Expense
+                        account associated with the service/non-sellable-item billing.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +80,8 @@ class IPPAccountBasedExpenseLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: The billable status of the expense.[br /]
+                        Description: The billable status of
+                        the expense.[br /]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -88,7 +93,8 @@ class IPPAccountBasedExpenseLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Markup information for the expense.
+                        Description: Markup information for
+                        the expense.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -100,7 +106,8 @@ class IPPAccountBasedExpenseLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Sales tax associated with the expense.
+                        Description: Sales tax associated
+                        with the expense.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -112,7 +119,8 @@ class IPPAccountBasedExpenseLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Sales tax code associated with the sales tax for the expense.
+                        Description: Sales tax code
+                        associated with the sales tax for the expense.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -124,7 +132,8 @@ class IPPAccountBasedExpenseLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: Indicates the total amount of line item including tax.
+                        Description: Indicates the total
+                        amount of line item including tax.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -136,7 +145,8 @@ class IPPAccountBasedExpenseLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Internal use only: extension place holder for ExpenseDetail
+                        Description: Internal use only:
+                        extension place holder for ExpenseDetail
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPAccountClassificationEnum.php
+++ b/src/Data/IPPAccountClassificationEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPAccountClassificationEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of basic Account types used generally in the accounting activities.
+                Description: Enumeration of basic
+                Account types used generally in the accounting activities.
 
  */
 class IPPAccountClassificationEnum
@@ -23,22 +24,22 @@ class IPPAccountClassificationEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAccountClassificationEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAccountClassificationEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAccountClassificationEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAccountClassificationEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPAccountClassificationEnum

--- a/src/Data/IPPAccountSubTypeEnum.php
+++ b/src/Data/IPPAccountSubTypeEnum.php
@@ -7,9 +7,10 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPAccountSubTypeEnum
  * @var IPPAccountSubTypeEnum
  * @xmlDefinition
-                Product: QBO
-                Description: Enumeration of Account sub-types used to specifically categorize account types in QuickBooks Online.
+                        Product: QBO
+                        Description: Use Tax Roundoff Gain or Loss to track gains or losses that occur as a result of Tax filing roundoff.
 
+ * @xmlb Share Application Money Pending Allotment
  */
 class IPPAccountSubTypeEnum
 {
@@ -23,22 +24,22 @@ class IPPAccountSubTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAccountSubTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAccountSubTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAccountSubTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAccountSubTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPAccountSubTypeEnum

--- a/src/Data/IPPAccountTypeEnum.php
+++ b/src/Data/IPPAccountTypeEnum.php
@@ -8,7 +8,10 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPAccountTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of Account sub-types(QBW) and Account types(QBO) used to specifically categorize accounts.  Note: QBO doesn't support the "Non-Posting" Account type.
+                Description: Enumeration of Account
+                sub-types(QBW) and Account types(QBO) used to specifically
+                categorize accounts. Note: QBO doesn't support the "Non-Posting"
+                Account type.
 
  */
 class IPPAccountTypeEnum
@@ -23,22 +26,22 @@ class IPPAccountTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAccountTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAccountTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAccountTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAccountTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPAccountTypeEnum

--- a/src/Data/IPPAcquiredAsEnum.php
+++ b/src/Data/IPPAcquiredAsEnum.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType string
  * @xmlName IPPAcquiredAsEnum
  * @var IPPAcquiredAsEnum
- * @xmlDefinition enumeration of how the Fixed Asset has been acquired
+ * @xmlDefinition enumeration of how the Fixed Asset has been
+                acquired
  */
 class IPPAcquiredAsEnum
 {
@@ -20,22 +21,22 @@ class IPPAcquiredAsEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAcquiredAsEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAcquiredAsEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAcquiredAsEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAcquiredAsEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPAcquiredAsEnum

--- a/src/Data/IPPAdvancedInventoryPrefs.php
+++ b/src/Data/IPPAdvancedInventoryPrefs.php
@@ -7,6 +7,7 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPAdvancedInventoryPrefs
  * @var IPPAdvancedInventoryPrefs
  * @xmlDefinition QBW: only. Defines advance inventory Prefs details
+
  */
 class IPPAdvancedInventoryPrefs
 {
@@ -20,20 +21,20 @@ class IPPAdvancedInventoryPrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAdvancedInventoryPrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAdvancedInventoryPrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAdvancedInventoryPrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAdvancedInventoryPrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition QBW: ONLY. MLI available
      * @xmlType element
@@ -127,7 +128,8 @@ class IPPAdvancedInventoryPrefs
     /**
      * @Definition
                         Product: QBW
-                        Description: Indicates whether Row/Shelf/Bin location tracking is enabled
+                        Description: Indicates whether
+                        Row/Shelf/Bin location tracking is enabled
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -139,7 +141,8 @@ class IPPAdvancedInventoryPrefs
     /**
      * @Definition
                         Product: QBW
-                        Description: Indicates whether barcoding is enabled
+                        Description: Indicates whether
+                        barcoding is enabled
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPAttachable.php
+++ b/src/Data/IPPAttachable.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPAttachable
  * @xmlDefinition
                 Product: ALL
-                Description: Describes the details of the attachment.
+                Description: Describes the details of
+                the attachment.
 
  */
 class IPPAttachable extends IPPIntuitEntity
@@ -23,20 +24,20 @@ class IPPAttachable extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAttachable', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAttachable', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAttachable', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAttachable', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition FileName of the attachment
                                 Max Length: 1000
@@ -49,7 +50,8 @@ class IPPAttachable extends IPPIntuitEntity
      */
     public $FileName;
     /**
-     * @Definition FullPath FileAccess URI of the attachment, output only
+     * @Definition FullPath FileAccess URI of the attachment,
+                                output only
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -59,7 +61,8 @@ class IPPAttachable extends IPPIntuitEntity
      */
     public $FileAccessUri;
     /**
-     * @Definition Output only. TempDownload URI which can be directly downloaded by clients
+     * @Definition Output only. TempDownload URI which can be
+                                directly downloaded by clients
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -99,7 +102,8 @@ class IPPAttachable extends IPPIntuitEntity
      */
     public $Category;
     /**
-     * @Definition  Latitude from where the attachment was requested
+     * @Definition  Latitude from where the attachment was
+                                requested
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -109,7 +113,8 @@ class IPPAttachable extends IPPIntuitEntity
      */
     public $Lat;
     /**
-     * @Definition  Longitude from where the attachment was requested
+     * @Definition  Longitude from where the attachment was
+                                requested
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -119,7 +124,8 @@ class IPPAttachable extends IPPIntuitEntity
      */
     public $Long;
     /**
-     * @Definition  PlaceName from where the attachment was requested
+     * @Definition  PlaceName from where the attachment was
+                                requested
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -149,7 +155,9 @@ class IPPAttachable extends IPPIntuitEntity
      */
     public $Tag;
     /**
-     * @Definition FullPath FileAccess URI of the attachment thumbnail if the attachment file is of a content type with thumbnail support, output only
+     * @Definition FullPath FileAccess URI of the attachment
+                                thumbnail if the attachment file is of a content type with
+                                thumbnail support, output only
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -159,7 +167,9 @@ class IPPAttachable extends IPPIntuitEntity
      */
     public $ThumbnailFileAccessUri;
     /**
-     * @Definition Output only. Thumbnail TempDownload URI which can be directly downloaded by clients. This is only available if the attachment file is of a content type with thumbnail support
+     * @Definition Output only. Thumbnail TempDownload URI which
+                                can be directly downloaded by clients. This is only available if
+                                the attachment file is of a content type with thumbnail support
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPAttachableCategoryEnum.php
+++ b/src/Data/IPPAttachableCategoryEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPAttachableCategoryEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Category values for Attachable
+                Description: Category values for
+                Attachable
 
  */
 class IPPAttachableCategoryEnum
@@ -23,22 +24,22 @@ class IPPAttachableCategoryEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAttachableCategoryEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAttachableCategoryEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAttachableCategoryEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAttachableCategoryEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPAttachableCategoryEnum

--- a/src/Data/IPPAttachableRef.php
+++ b/src/Data/IPPAttachableRef.php
@@ -23,20 +23,20 @@ class IPPAttachableRef
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAttachableRef', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAttachableRef', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAttachableRef', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAttachableRef', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPAttachableResponse.php
+++ b/src/Data/IPPAttachableResponse.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPAttachableResponse
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAttachableResponse', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAttachableResponse', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAttachableResponse', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAttachableResponse', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition Upload file metat data
@@ -44,6 +44,7 @@ class IPPAttachableResponse
      * @var com\intuit\schema\finance\v3\IPPAttachable
      */
     public $Attachable;
+
     /**
      * @Definition Fault if upload file is not successful
      * @xmlType element
@@ -54,4 +55,6 @@ class IPPAttachableResponse
      * @var com\intuit\schema\finance\v3\IPPFault
      */
     public $Fault;
-} // end class IPPAttachableResponse
+}//end class
+
+ // end class IPPAttachableResponse

--- a/src/Data/IPPAttribute.php
+++ b/src/Data/IPPAttribute.php
@@ -10,28 +10,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPAttribute
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAttribute', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAttribute', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAttribute', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAttribute', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition Describes the Name
@@ -41,6 +41,7 @@ class IPPAttribute
      * @var string
      */
     public $Type;
+
     /**
      * @Definition Describes the Value
      * @xmlType element
@@ -49,4 +50,6 @@ class IPPAttribute
      * @var string
      */
     public $Value;
-} // end class IPPAttribute
+}//end class
+
+ // end class IPPAttribute

--- a/src/Data/IPPAttributes.php
+++ b/src/Data/IPPAttributes.php
@@ -10,28 +10,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPAttributes
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPAttributes', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAttributes', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPAttributes', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPAttributes', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition Describes the type
@@ -43,4 +43,6 @@ class IPPAttributes
      * @var com\intuit\schema\finance\v3\IPPAttribute
      */
     public $Attribute;
-} // end class IPPAttributes
+}//end class
+
+ // end class IPPAttributes

--- a/src/Data/IPPBatchItemRequest.php
+++ b/src/Data/IPPBatchItemRequest.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPBatchItemRequest
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPBatchItemRequest', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBatchItemRequest', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPBatchItemRequest', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPBatchItemRequest', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @xmlType element
@@ -40,6 +40,7 @@ class IPPBatchItemRequest
      * @var IntuitObject
      */
     public $IntuitObject;
+
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -49,6 +50,7 @@ class IPPBatchItemRequest
      * @var string
      */
     public $Query;
+
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -58,6 +60,7 @@ class IPPBatchItemRequest
      * @var string
      */
     public $ReportQuery;
+
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -67,6 +70,7 @@ class IPPBatchItemRequest
      * @var com\intuit\schema\finance\v3\IPPCDCQuery
      */
     public $CDCQuery;
+
     /**
      * @Definition Specifies the batch id for which the response corresponds to
      * @xmlType attribute
@@ -74,6 +78,7 @@ class IPPBatchItemRequest
      * @var string
      */
     public $bId;
+
     /**
      * @Definition Specifies the batch id for which the response corresponds to
      * @xmlType attribute
@@ -81,6 +86,7 @@ class IPPBatchItemRequest
      * @var OperationEnum
      */
     public $operation;
+
     /**
      * @Definition Specifies name value pair of options other than operations
      * @xmlType attribute
@@ -88,4 +94,6 @@ class IPPBatchItemRequest
      * @var string
      */
     public $optionsData;
-} // end class IPPBatchItemRequest
+}//end class
+
+ // end class IPPBatchItemRequest

--- a/src/Data/IPPBatchItemResponse.php
+++ b/src/Data/IPPBatchItemResponse.php
@@ -12,26 +12,26 @@ class IPPBatchItemResponse
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPBatchItemResponse', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBatchItemResponse', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPBatchItemResponse', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBatchItemResponse', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
 
     /**

--- a/src/Data/IPPBill.php
+++ b/src/Data/IPPBill.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType PurchaseByVendor
  * @xmlName IPPBill
  * @var IPPBill
- * @xmlDefinition Bill is an AP transaction representing a request-for-payment from a third party for goods/services rendered and/or received
+ * @xmlDefinition Bill is an AP transaction representing a
+                request-for-payment from a third party for goods/services rendered
+                and/or received
  */
 class IPPBill extends IPPPurchaseByVendor
 {
@@ -20,20 +22,20 @@ class IPPBill extends IPPPurchaseByVendor
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPBill', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBill', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPBill', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPBill', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBW
@@ -48,6 +50,7 @@ class IPPBill extends IPPPurchaseByVendor
     public $PayerRef;
     /**
      * @Definition SalesTerm Reference for the bill
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -56,7 +59,9 @@ class IPPBill extends IPPPurchaseByVendor
      */
     public $SalesTermRef;
     /**
-     * @Definition The nominal date by which the bill must be paid, not including any early-payment discount incentives, or late payment penalties.
+     * @Definition The nominal date by which the bill must be
+                                paid, not including any early-payment discount incentives, or
+                                late payment penalties.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -77,7 +82,8 @@ class IPPBill extends IPPPurchaseByVendor
      */
     public $RemitToAddr;
     /**
-     * @Definition Address to which the vendor shipped or will ship any goods associated with the purchase.
+     * @Definition Address to which the vendor shipped or will
+                                ship any goods associated with the purchase.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -87,12 +93,13 @@ class IPPBill extends IPPPurchaseByVendor
     public $ShipAddr;
     /**
      * @Definition
-                            Product: ALL
-                            Description: The unpaid amount of the bill.  When paid-in-full, balance will be zero.
+                                Product: ALL
+                                Description: The unpaid amount of the bill. When paid-in-full, balance will
+                                be zero.
                                 [b]QuickBooks Notes[/b][br /]
                                 Non QB-writable.
-                            Filterable: QBW
-                            Sortable: QBW
+                                Filterable: QBW
+                                Sortable: QBW
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -103,12 +110,15 @@ class IPPBill extends IPPPurchaseByVendor
     public $Balance;
     /**
      * @Definition
-                            Product: ALL
-                            Description: The unpaid amount of the bill in home currency. Available only for companies where multicurrency is enabled.  When paid-in-full, home balance will be zero.
+                                Product: ALL
+                                Description: The unpaid amount of the bill in home currency. Available only
+                                for companies where multicurrency is enabled. When paid-in-full,
+                                home balance will be zero.
                                 [b]QuickBooks Notes[/b][br /]
-                                Non QB-writable.
-                            Filterable: QBW
-                            Sortable: QBW
+                                Non
+                                QB-writable.
+                                Filterable: QBW
+                                Sortable: QBW
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -118,7 +128,8 @@ class IPPBill extends IPPPurchaseByVendor
      */
     public $HomeBalance;
     /**
-     * @Definition Internal use only: extension place holder for Bill.
+     * @Definition Internal use only: extension place holder for
+                                Bill.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPBillPayment.php
+++ b/src/Data/IPPBillPayment.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType Transaction
  * @xmlName IPPBillPayment
  * @var IPPBillPayment
- * @xmlDefinition Financial transaction representing a Payment by check issued to pay one or more bills received from 3rd party (vendor) for purchased goods or services.
+ * @xmlDefinition Financial transaction representing a Payment by
+                check issued to pay one or more bills received from 3rd party
+                (vendor) for purchased goods or services.
  */
 class IPPBillPayment extends IPPTransaction
 {
@@ -20,24 +22,26 @@ class IPPBillPayment extends IPPTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPBillPayment', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBillPayment', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPBillPayment', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPBillPayment', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition Identifies the party or organization that originated the purchase of the goods, services or BillPayment.
+     * @Definition Identifies the party or organization that
+                                originated the purchase of the goods, services or BillPayment.
                                 [b]QuickBooks Notes[/b][br /]
-                                Valid Vendor Name or Id is required for the create operation for Bill Payment transactions.[br /]
+                                Valid Vendor Name or Id is required
+                                for the create operation for Bill Payment transactions.[br /]
                                 Required for the create operation.
 
      * @xmlType element
@@ -48,9 +52,14 @@ class IPPBillPayment extends IPPTransaction
      */
     public $VendorRef;
     /**
-     * @Definition Optional AP account specification for bill payment transactions.  Most small businesses have a single AP account, so the account is implied.   When specified, the account must be a liability account - and further, must be of the sub-type "Payables".
+     * @Definition Optional AP account specification for bill
+                                payment transactions. Most small businesses have a single AP
+                                account, so the account is implied. When specified, the account
+                                must be a liability account - and further, must be of the
+                                sub-type "Payables".
                                 [b]QuickBooks Notes[/b][br /]
-                                The AP Account should always be specified or a default will be used.
+                                The AP Account
+                                should always be specified or a default will be used.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -89,8 +98,10 @@ class IPPBillPayment extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: The total amount paid, determined by taking the sum of all lines associated.
-                                InputType: QBW: ReadOnly
+                                Description: The total amount paid,
+                                determined by taking the sum of all lines associated.
+                                InputType:
+                                QBW: ReadOnly
                                 Filterable: QBW
                                 Sortable: QBW
 
@@ -102,7 +113,8 @@ class IPPBillPayment extends IPPTransaction
      */
     public $TotalAmt;
     /**
-     * @Definition Internal use only: extension place holder for BillPay
+     * @Definition Internal use only: extension place holder for
+                                BillPay
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPBillPaymentCheck.php
+++ b/src/Data/IPPBillPaymentCheck.php
@@ -19,20 +19,20 @@ class IPPBillPaymentCheck
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPBillPaymentCheck', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBillPaymentCheck', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPBillPaymentCheck', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPBillPaymentCheck', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +52,8 @@ class IPPBillPaymentCheck
     /**
      * @Definition
                         [b]QuickBooks Notes[/b][br /]
-                        [i]Unsupported field.[/i]
+                        [i]Unsupported
+                        field.[/i]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -63,6 +64,7 @@ class IPPBillPaymentCheck
     public $CheckDetail;
     /**
      * @Definition Address to which the payment should be sent.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -71,7 +73,8 @@ class IPPBillPaymentCheck
      */
     public $PayeeAddr;
     /**
-     * @Definition Internal use only: extension place holder for BillPaymentCheck.
+     * @Definition Internal use only: extension place holder for
+                        BillPaymentCheck.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPBillPaymentCreditCard.php
+++ b/src/Data/IPPBillPaymentCreditCard.php
@@ -19,20 +19,20 @@ class IPPBillPaymentCreditCard
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPBillPaymentCreditCard', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBillPaymentCreditCard', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPBillPaymentCreditCard', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPBillPaymentCreditCard', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -50,7 +50,8 @@ class IPPBillPaymentCreditCard
      */
     public $CCDetail;
     /**
-     * @Definition Internal use only: extension place holder for BillPayTypeCreditCard
+     * @Definition Internal use only: extension place holder for
+                        BillPayTypeCreditCard
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPBillPaymentTypeEnum.php
+++ b/src/Data/IPPBillPaymentTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPBillPaymentTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of bill payment types.
+                Description: Enumeration of bill
+                payment types.
 
  */
 class IPPBillPaymentTypeEnum
@@ -23,22 +24,22 @@ class IPPBillPaymentTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPBillPaymentTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBillPaymentTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPBillPaymentTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPBillPaymentTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPBillPaymentTypeEnum

--- a/src/Data/IPPBillableStatusEnum.php
+++ b/src/Data/IPPBillableStatusEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPBillableStatusEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of Billable Status used when searching for reimbursable expenses.
+                Description: Enumeration of Billable
+                Status used when searching for reimbursable expenses.
 
  */
 class IPPBillableStatusEnum
@@ -23,22 +24,22 @@ class IPPBillableStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPBillableStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBillableStatusEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPBillableStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPBillableStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPBillableStatusEnum

--- a/src/Data/IPPBooleanTypeCustomFieldDefinition.php
+++ b/src/Data/IPPBooleanTypeCustomFieldDefinition.php
@@ -23,20 +23,20 @@ class IPPBooleanTypeCustomFieldDefinition extends IPPCustomFieldDefinition
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPBooleanTypeCustomFieldDefinition', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBooleanTypeCustomFieldDefinition', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPBooleanTypeCustomFieldDefinition', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPBooleanTypeCustomFieldDefinition', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL

--- a/src/Data/IPPBudget.php
+++ b/src/Data/IPPBudget.php
@@ -20,24 +20,24 @@ class IPPBudget extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPBudget', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBudget', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPBudget', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPBudget', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
-                                                                Product: QBO
-                                                                Description: Name of the budget
+                                Product: QBO
+                                Description: Name of the budget
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -49,8 +49,8 @@ class IPPBudget extends IPPIntuitEntity
     public $Name;
     /**
      * @Definition
-                                                                Product: QBO
-                                                                Description: Starting date of the budget
+                                Product: QBO
+                                Description: Starting date of the budget
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -62,8 +62,8 @@ class IPPBudget extends IPPIntuitEntity
     public $StartDate;
     /**
      * @Definition
-                                                                Product: QBO
-                                                                Description: End date of the budget
+                                Product: QBO
+                                Description: End date of the budget
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -75,8 +75,8 @@ class IPPBudget extends IPPIntuitEntity
     public $EndDate;
     /**
      * @Definition
-                                                                Product: QBO
-                                                                Description: Budget Type
+                                Product: QBO
+                                Description: Budget Type
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -88,8 +88,8 @@ class IPPBudget extends IPPIntuitEntity
     public $BudgetType;
     /**
      * @Definition
-                                                                Product: QBO
-                                                                Description: Budget Entry Type
+                                Product: QBO
+                                Description: Budget Entry Type
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -101,8 +101,8 @@ class IPPBudget extends IPPIntuitEntity
     public $BudgetEntryType;
     /**
      * @Definition
-                                                                Product: QBO
-                                                                Description: Active budget or inactive
+                                Product: QBO
+                                Description: Active budget or inactive
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -114,8 +114,8 @@ class IPPBudget extends IPPIntuitEntity
     public $Active;
     /**
      * @Definition
-                                                                Product: QBO
-                                                                Description: Budget details are here
+                                Product: QBO
+                                Description: Budget details are here
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPBudgetDetail.php
+++ b/src/Data/IPPBudgetDetail.php
@@ -7,6 +7,7 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPBudgetDetail
  * @var IPPBudgetDetail
  * @xmlDefinition Describes budget details for each budget
+
  */
 class IPPBudgetDetail
 {
@@ -20,24 +21,24 @@ class IPPBudgetDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPBudgetDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBudgetDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPBudgetDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPBudgetDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
-                                                Product: QBO
-                                                Description: Budget date of the budget
+                        Product: QBO
+                        Description: Budget date of the budget
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -49,8 +50,9 @@ class IPPBudgetDetail
     public $BudgetDate;
     /**
      * @Definition
-                                                Product: QBO
-                                                Description: Amount corresponding to the budget date and Account or Class Or Department or Customer
+                        Product: QBO
+                        Description: Amount corresponding to the budget date and Account or Class Or
+                        Department or Customer
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -62,8 +64,8 @@ class IPPBudgetDetail
     public $Amount;
     /**
      * @Definition
-                                                Product: QBO
-                                                Description: Account Reference
+                        Product: QBO
+                        Description: Account Reference
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -75,8 +77,8 @@ class IPPBudgetDetail
     public $AccountRef;
     /**
      * @Definition
-                                                Product: QBO
-                                                Description: Customer Reference
+                        Product: QBO
+                        Description: Customer Reference
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -88,8 +90,8 @@ class IPPBudgetDetail
     public $CustomerRef;
     /**
      * @Definition
-                                                Product: QBO
-                                                Description: Class Reference
+                        Product: QBO
+                        Description: Class Reference
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -101,8 +103,8 @@ class IPPBudgetDetail
     public $ClassRef;
     /**
      * @Definition
-                                                Product: QBO
-                                                Description: Department Reference
+                        Product: QBO
+                        Description: Department Reference
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPBudgetEntryTypeEnum.php
+++ b/src/Data/IPPBudgetEntryTypeEnum.php
@@ -7,8 +7,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPBudgetEntryTypeEnum
  * @var IPPBudgetEntryTypeEnum
  * @xmlDefinition
-                                Product: ALL
-                                Description: Enumeration of BudgetEntry Type
+                Product: ALL
+                Description: Enumeration of BudgetEntry Type
 
  */
 class IPPBudgetEntryTypeEnum
@@ -23,22 +23,22 @@ class IPPBudgetEntryTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPBudgetEntryTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPBudgetEntryTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPBudgetEntryTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPBudgetEntryTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPBudgetEntryTypeEnum

--- a/src/Data/IPPCCAVSMatchEnum.php
+++ b/src/Data/IPPCCAVSMatchEnum.php
@@ -23,22 +23,22 @@ class IPPCCAVSMatchEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCCAVSMatchEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCCAVSMatchEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCCAVSMatchEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCCAVSMatchEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPCCAVSMatchEnum

--- a/src/Data/IPPCCPaymentStatusEnum.php
+++ b/src/Data/IPPCCPaymentStatusEnum.php
@@ -23,22 +23,22 @@ class IPPCCPaymentStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCCPaymentStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCCPaymentStatusEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCCPaymentStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCCPaymentStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPCCPaymentStatusEnum

--- a/src/Data/IPPCCSecurityCodeMatchEnum.php
+++ b/src/Data/IPPCCSecurityCodeMatchEnum.php
@@ -23,22 +23,22 @@ class IPPCCSecurityCodeMatchEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCCSecurityCodeMatchEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCCSecurityCodeMatchEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCCSecurityCodeMatchEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCCSecurityCodeMatchEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPCCSecurityCodeMatchEnum

--- a/src/Data/IPPCCTxnModeEnum.php
+++ b/src/Data/IPPCCTxnModeEnum.php
@@ -23,22 +23,22 @@ class IPPCCTxnModeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCCTxnModeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCCTxnModeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCCTxnModeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCCTxnModeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPCCTxnModeEnum

--- a/src/Data/IPPCCTxnTypeEnum.php
+++ b/src/Data/IPPCCTxnTypeEnum.php
@@ -23,22 +23,22 @@ class IPPCCTxnTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCCTxnTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCCTxnTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCCTxnTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCCTxnTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPCCTxnTypeEnum

--- a/src/Data/IPPCDCQuery.php
+++ b/src/Data/IPPCDCQuery.php
@@ -12,26 +12,26 @@ class IPPCDCQuery
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCDCQuery', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCDCQuery', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCDCQuery', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCDCQuery', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
 
     /**

--- a/src/Data/IPPCDCResponse.php
+++ b/src/Data/IPPCDCResponse.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPCDCResponse
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCDCResponse', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCDCResponse', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCDCResponse', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCDCResponse', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition Any IntuitEntity derived object like Customer, Invoice can be part of response
@@ -44,6 +44,7 @@ class IPPCDCResponse
      * @var com\intuit\schema\finance\v3\IPPQueryResponse
      */
     public $QueryResponse;
+
     /**
      * @Definition  Fault or Object should be returned
      * @xmlType element
@@ -54,6 +55,7 @@ class IPPCDCResponse
      * @var com\intuit\schema\finance\v3\IPPFault
      */
     public $Fault;
+
     /**
      * @Definition Specifies the number of rows in this result
      * @xmlType attribute
@@ -61,4 +63,6 @@ class IPPCDCResponse
      * @var integer
      */
     public $size;
-} // end class IPPCDCResponse
+}//end class
+
+ // end class IPPCDCResponse

--- a/src/Data/IPPCascade.php
+++ b/src/Data/IPPCascade.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPCascade
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCascade', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCascade', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCascade', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCascade', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition  Any IntuitEntity derived object name like Customer, Item, Invoice, ...
@@ -43,6 +43,7 @@ class IPPCascade
      * @var string
      */
     public $EntityName;
+
     /**
      * @Definition  Description: Unique identifier for an Intuit entity.
      * @xmlType element
@@ -52,6 +53,7 @@ class IPPCascade
      * @var com\intuit\schema\finance\v3\IPPid
      */
     public $Id;
+
     /**
      * @Definition  Cascading events resulting from a transaction event in the form of key value pairs. Key names are user defined.
      * @xmlType element
@@ -62,4 +64,6 @@ class IPPCascade
      * @var com\intuit\schema\finance\v3\IPPNameValue
      */
     public $KeyValue;
-} // end class IPPCascade
+}//end class
+
+ // end class IPPCascade

--- a/src/Data/IPPCascadeResponse.php
+++ b/src/Data/IPPCascadeResponse.php
@@ -12,26 +12,26 @@ class IPPCascadeResponse
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCascadeResponse', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCascadeResponse', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCascadeResponse', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCascadeResponse', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
 
     /**

--- a/src/Data/IPPCashBackInfo.php
+++ b/src/Data/IPPCashBackInfo.php
@@ -19,24 +19,26 @@ class IPPCashBackInfo
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCashBackInfo', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCashBackInfo', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCashBackInfo', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCashBackInfo', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition AccountReferenceGroup Identifies the Asset Account (bank account) to be used for this Cash back.
+     * @Definition AccountReferenceGroup Identifies the Asset
+                        Account (bank account) to be used for this Cash back.
                         [b]QuickBooks Notes[/b][br /]
-                        Required for the create operation. [br /]
+                        Required for the create operation.
+                        [br /]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPCashPurchase.php
+++ b/src/Data/IPPCashPurchase.php
@@ -7,6 +7,7 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPCashPurchase
  * @var IPPCashPurchase
  * @xmlDefinition Cash based expense type definition
+
  */
 class IPPCashPurchase
 {
@@ -20,20 +21,20 @@ class IPPCashPurchase
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCashPurchase', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCashPurchase', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCashPurchase', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCashPurchase', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPChargeCredit.php
+++ b/src/Data/IPPChargeCredit.php
@@ -6,8 +6,10 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType Transaction
  * @xmlName IPPChargeCredit
  * @var IPPChargeCredit
- * @xmlDefinition Financial transaction representing a request for credit on payment for
+ * @xmlDefinition Financial transaction representing a request for
+                credit on payment for
                 goods or services that have been sold.
+
  */
 class IPPChargeCredit extends IPPTransaction
 {
@@ -21,20 +23,20 @@ class IPPChargeCredit extends IPPTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPChargeCredit', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPChargeCredit', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPChargeCredit', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPChargeCredit', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition If Credit is Null or False, it is considered as
                                 Charge. If true, the ChargeCredit represents a Refund
@@ -57,9 +59,12 @@ class IPPChargeCredit extends IPPTransaction
      */
     public $CustomerRef;
     /**
-     * @Definition Identifies the party or location that the payment is
-                                to be remitted to or sent to. [b]QuickBooks Notes[/b][br /] Non
+     * @Definition Identifies the party or location that the
+                                payment is
+                                to be remitted to or sent to. [b]QuickBooks
+                                Notes[/b][br /] Non
                                 QB-writable.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -68,9 +73,12 @@ class IPPChargeCredit extends IPPTransaction
      */
     public $RemitToRef;
     /**
-     * @Definition ARAccountReferenceGroup Identifies the AR Account to
-                                be used for this Credit Memo. [b]QuickBooks Notes[/b][br /] The AR
-                                Account should always be specified or a default will be used.
+     * @Definition ARAccountReferenceGroup Identifies the AR
+                                Account to
+                                be used for this Credit Memo. [b]QuickBooks
+                                Notes[/b][br /] The AR
+                                Account should always be specified or a
+                                default will be used.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -108,9 +116,13 @@ class IPPChargeCredit extends IPPTransaction
      */
     public $BilledDate;
     /**
-     * @Definition Indicates the total amount of the entity associated.
-                                This includes the total of all the charges, allowances and taxes.
-                                [b]QuickBooks Notes[/b][br /] Non QB-writable.
+     * @Definition Indicates the total amount of the entity
+                                associated.
+                                This includes the total of all the charges,
+                                allowances and taxes.
+                                [b]QuickBooks Notes[/b][br /] Non
+                                QB-writable.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -121,6 +133,7 @@ class IPPChargeCredit extends IPPTransaction
     /**
      * @Definition Internal use only: extension place holder for
                                 ChargeCredit
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPCheckPayment.php
+++ b/src/Data/IPPCheckPayment.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPCheckPayment
  * @xmlDefinition
                 Product: ALL
-                Description: Check payment details for both payments to vendors and payments from customers.
+                Description: Check payment details for
+                both payments to vendors and payments from customers.
 
  */
 class IPPCheckPayment
@@ -23,24 +24,25 @@ class IPPCheckPayment
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCheckPayment', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCheckPayment', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCheckPayment', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCheckPayment', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: The check number printed on the check.
+                        Description: The check number printed
+                        on the check.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +54,8 @@ class IPPCheckPayment
     /**
      * @Definition
                         Product: ALL
-                        Description: Status of the check. Values provided by service/business logic.
+                        Description: Status of the check.
+                        Values provided by service/business logic.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +67,8 @@ class IPPCheckPayment
     /**
      * @Definition
                         Product: ALL
-                        Description: Name of persons or entities holding the account, as printed on the check.
+                        Description: Name of persons or
+                        entities holding the account, as printed on the check.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +80,8 @@ class IPPCheckPayment
     /**
      * @Definition
                         Product: ALL
-                        Description: Checking account number, as printed on the check.
+                        Description: Checking account number,
+                        as printed on the check.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -88,7 +93,8 @@ class IPPCheckPayment
     /**
      * @Definition
                         Product: ALL
-                        Description: The name of the bank on which the check was drawn.
+                        Description: The name of the bank on
+                        which the check was drawn.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -100,7 +106,8 @@ class IPPCheckPayment
     /**
      * @Definition
                         Product: ALL
-                        Description: Internal use only: extension place holder for CheckPayment
+                        Description: Internal use only:
+                        extension place holder for CheckPayment
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPClass.php
+++ b/src/Data/IPPClass.php
@@ -6,7 +6,10 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType IntuitEntity
  * @xmlName IPPClass
  * @var IPPClass
- * @xmlDefinition Classes provide a way to track different segments of the business, and to break down the income and expenses for each segment. Classes can apply to all transactions, so they're not tied to a particular client or project.
+ * @xmlDefinition Classes provide a way to track different segments
+                of the business, and to break down the income and expenses for each
+                segment. Classes can apply to all transactions, so they're not tied
+                to a particular client or project.
  */
 class IPPClass extends IPPIntuitEntity
 {
@@ -20,20 +23,20 @@ class IPPClass extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPClass', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPClass', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPClass', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPClass', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition User recognizable name for the Class.[br /]
                                 Length Restriction:
@@ -49,7 +52,8 @@ class IPPClass extends IPPIntuitEntity
      */
     public $Name;
     /**
-     * @Definition  Specifies the Class is a SubClass or Not. True if subclass, false or null if it is top-level class
+     * @Definition  Specifies the Class is a SubClass or Not. True
+                                if subclass, false or null if it is top-level class
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -60,6 +64,7 @@ class IPPClass extends IPPIntuitEntity
     public $SubClass;
     /**
      * @Definition Reference to parent class entity
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -70,7 +75,11 @@ class IPPClass extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Output Only. Fully qualified name of the entity. The fully qualified name prepends the topmost parent, followed by each sub element separated by colons. Takes the form of: [br /]Parent:class1:Subclass1:Subclass2
+                                Description: Output Only. Fully
+                                qualified name of the entity. The fully qualified name prepends
+                                the topmost parent, followed by each sub element separated by
+                                colons. Takes the form of: [br
+                                /]Parent:class1:Subclass1:Subclass2
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -80,7 +89,9 @@ class IPPClass extends IPPIntuitEntity
      */
     public $FullyQualifiedName;
     /**
-     * @Definition Whether or not active inactive classes may be hidden from most display purposes and may not be used on financial transactions
+     * @Definition Whether or not active inactive classes may be
+                                hidden from most display purposes and may not be used on
+                                financial transactions
                                 Filterable: ALL
 
      * @xmlType element
@@ -91,7 +102,8 @@ class IPPClass extends IPPIntuitEntity
      */
     public $Active;
     /**
-     * @Definition Internal use only: extension place holder for Class extensible element
+     * @Definition Internal use only: extension place holder for
+                                Class extensible element
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPColData.php
+++ b/src/Data/IPPColData.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPColData
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPColData', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPColData', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPColData', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPColData', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition Describes the column attributes
@@ -43,18 +43,21 @@ class IPPColData
      * @var com\intuit\schema\finance\v3\IPPAttributes
      */
     public $Attributes;
+
     /**
      * @xmlType attribute
      * @xmlName value
      * @var string
      */
     public $value;
+
     /**
      * @xmlType attribute
      * @xmlName id
      * @var string
      */
     public $id;
+
     /**
      * @Definition Reference url
      * @xmlType attribute
@@ -62,4 +65,6 @@ class IPPColData
      * @var string
      */
     public $href;
-} // end class IPPColData
+}//end class
+
+ // end class IPPColData

--- a/src/Data/IPPColumn.php
+++ b/src/Data/IPPColumn.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPColumn
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPColumn', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPColumn', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPColumn', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPColumn', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition Describes the column title name
@@ -42,6 +42,7 @@ class IPPColumn
      * @var string
      */
     public $ColTitle;
+
     /**
      * @Definition Describes the column type enumeration
      * @xmlType element
@@ -50,6 +51,7 @@ class IPPColumn
      * @var string
      */
     public $ColType;
+
     /**
      * @Definition Column Metadata
      * @xmlType element
@@ -60,6 +62,7 @@ class IPPColumn
      * @var com\intuit\schema\finance\v3\IPPNameValue
      */
     public $MetaData;
+
     /**
      * @Definition Subcolumns of the column
      * @xmlType element
@@ -69,4 +72,6 @@ class IPPColumn
      * @var com\intuit\schema\finance\v3\IPPColumns
      */
     public $Columns;
-} // end class IPPColumn
+}//end class
+
+ // end class IPPColumn

--- a/src/Data/IPPColumnTypeEnum.php
+++ b/src/Data/IPPColumnTypeEnum.php
@@ -12,30 +12,30 @@ class IPPColumnTypeEnum
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPColumnTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPColumnTypeEnum', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPColumnTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPColumnTypeEnum', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPColumnTypeEnum

--- a/src/Data/IPPColumns.php
+++ b/src/Data/IPPColumns.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPColumns
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPColumns', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPColumns', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPColumns', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPColumns', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition Column of the report
@@ -44,4 +44,6 @@ class IPPColumns
      * @var com\intuit\schema\finance\v3\IPPColumn
      */
     public $Column;
-} // end class IPPColumns
+}//end class
+
+ // end class IPPColumns

--- a/src/Data/IPPCompany.php
+++ b/src/Data/IPPCompany.php
@@ -20,20 +20,20 @@ class IPPCompany extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCompany', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCompany', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCompany', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCompany', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL
@@ -48,6 +48,7 @@ class IPPCompany extends IPPIntuitEntity
     public $CompanyName;
     /**
      * @Definition LegalName if different from the CompanyName
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -57,6 +58,7 @@ class IPPCompany extends IPPIntuitEntity
     public $LegalName;
     /**
      * @Definition Company Address as described in preference
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -65,7 +67,9 @@ class IPPCompany extends IPPIntuitEntity
      */
     public $CompanyAddr;
     /**
-     * @Definition Address of the company as given to th customer, sometimes the address given to the customer mail address is different from Company address
+     * @Definition Address of the company as given to th customer,
+                                sometimes the address given to the customer mail address is
+                                different from Company address
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -74,7 +78,8 @@ class IPPCompany extends IPPIntuitEntity
      */
     public $CustomerCommunicationAddr;
     /**
-     * @Definition Legal Address given to the government for any government communication
+     * @Definition Legal Address given to the government for any
+                                government communication
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -92,7 +97,9 @@ class IPPCompany extends IPPIntuitEntity
      */
     public $CompanyEmailAddr;
     /**
-     * @Definition Email Address published to customer for communication if different from CompanyEmailAddress
+     * @Definition Email Address published to customer for
+                                communication if different from CompanyEmailAddress
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -121,7 +128,9 @@ class IPPCompany extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: List of ContactInfo entities of any contact info type. The ContactInfo Type values are defined in the ContactTypeEnum.
+                                Description: List of ContactInfo
+                                entities of any contact info type. The ContactInfo Type values
+                                are defined in the ContactTypeEnum.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -134,7 +143,8 @@ class IPPCompany extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: QuickBooks company file name.[br /]Data Services max. length: 512 characters.
+                                Description: QuickBooks company
+                                file name.[br /]Data Services max. length: 512 characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -146,7 +156,9 @@ class IPPCompany extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: QB software flavor being used on the file on the PC.[br /]Data Services max. length: 512 characters.
+                                Description: QB software flavor
+                                being used on the file on the PC.[br /]Data Services max.
+                                length: 512 characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -170,7 +182,10 @@ class IPPCompany extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: IAM or QBN admin users id sequence number to group many external realms for this user under his id number.[br /]Data Services max. length: 512 characters.
+                                Description: IAM or QBN admin users
+                                id sequence number to group many external realms for this user
+                                under his id number.[br /]Data Services max. length: 512
+                                characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -182,7 +197,8 @@ class IPPCompany extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: IAM or QBN admin users email.[br /]Data Services max. length: 100 characters.
+                                Description: IAM or QBN admin users
+                                email.[br /]Data Services max. length: 100 characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -242,7 +258,11 @@ class IPPCompany extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: QuickBooks company file latest version. The format reports the major release in the first number, the minor release in the second number (always a zero), the release update (slipstream or "R") in the third number, and the build number in the final number.[br /]Max. length: 512 characters.
+                                Description: QuickBooks company file latest version. The format reports the
+                                major release in the first number, the minor release in the
+                                second number (always a zero), the release update (slipstream or
+                                "R") in the third number, and the build number in the final
+                                number.[br /]Max. length: 512 characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -254,7 +274,8 @@ class IPPCompany extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Country name to which the company belongs for fiancial calculations.
+                                Description: Country name to which the company belongs for fiancial
+                                calculations.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -351,6 +372,7 @@ class IPPCompany extends IPPIntuitEntity
     public $LastImportedTime;
     /**
      * @Definition Comma separated list of languages
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -360,6 +382,7 @@ class IPPCompany extends IPPIntuitEntity
     public $SupportedLanguages;
     /**
      * @Definition Default time zone for the company
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -368,7 +391,8 @@ class IPPCompany extends IPPIntuitEntity
      */
     public $DefaultTimeZone;
     /**
-     * @Definition Specifies if the company support multibyte or not
+     * @Definition Specifies if the company support multibyte or
+                                not
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -377,7 +401,9 @@ class IPPCompany extends IPPIntuitEntity
      */
     public $MultiByteCharsSupported;
     /**
-     * @Definition Any other preference not covered in base is covered as name value pair, for detailed explanation look at the document
+     * @Definition Any other preference not covered in base is
+                                covered as name value pair, for detailed explanation look at the
+                                document
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPCompanyAccountingPrefs.php
+++ b/src/Data/IPPCompanyAccountingPrefs.php
@@ -7,6 +7,7 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPCompanyAccountingPrefs
  * @var IPPCompanyAccountingPrefs
  * @xmlDefinition Defines Company Accounting Prefs details
+
  */
 class IPPCompanyAccountingPrefs
 {
@@ -20,20 +21,20 @@ class IPPCompanyAccountingPrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCompanyAccountingPrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCompanyAccountingPrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCompanyAccountingPrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCompanyAccountingPrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition QBW: Only QBW supported
      * @xmlType element
@@ -65,6 +66,7 @@ class IPPCompanyAccountingPrefs
      * @Definition
                         Product:QBW
                         Requires account
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -75,7 +77,9 @@ class IPPCompanyAccountingPrefs
     /**
      * @Definition
                         Product:QBO
-                        QBO: QBO only. Enable Department Tracking
+                        QBO: QBO only. Enable Department
+                        Tracking
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -99,6 +103,7 @@ class IPPCompanyAccountingPrefs
      * @Definition
                         Product:All
                         Enable Class Tracking per transaction
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -109,7 +114,9 @@ class IPPCompanyAccountingPrefs
     /**
      * @Definition
                         Product:QBO
-                        Enable Class Tracking per transaction line
+                        Enable Class Tracking per transaction
+                        line
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -119,6 +126,7 @@ class IPPCompanyAccountingPrefs
     public $ClassTrackingPerTxnLine;
     /**
      * @Definition QBW: ONLY. Enable auto journal entry number
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -130,6 +138,7 @@ class IPPCompanyAccountingPrefs
      * @Definition
                         Product:All
                         Defines first Month of physical year
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -141,6 +150,7 @@ class IPPCompanyAccountingPrefs
      * @Definition
                         Product:All
                         Defines Tax Year Month
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -160,7 +170,9 @@ class IPPCompanyAccountingPrefs
     /**
      * @Definition
                         Product:All
-                        Book closing date, if you want to specify if not leave it as null
+                        Book closing date, if you want to
+                        specify if not leave it as null
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPCompanyCurrency.php
+++ b/src/Data/IPPCompanyCurrency.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType IntuitEntity
  * @xmlName IPPCompanyCurrency
  * @var IPPCompanyCurrency
- * @xmlDefinition Company currency are the currencies used by the company. Each Company Currency describes the properties of that currency.
+ * @xmlDefinition Company currency are the currencies used by the
+                company. Each Company Currency describes the properties of that
+                currency.
  */
 class IPPCompanyCurrency extends IPPIntuitEntity
 {
@@ -20,24 +22,26 @@ class IPPCompanyCurrency extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCompanyCurrency', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCompanyCurrency', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCompanyCurrency', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCompanyCurrency', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBO
-                                Description: Universal 3-letter currency code like USD, CAD, EUR, etc. Required for the create/delete operation.
+                                Description: Universal 3-letter
+                                currency code like USD, CAD, EUR, etc. Required for the
+                                create/delete operation.
                                 Max Length: 3
 
      * @xmlType element
@@ -50,7 +54,8 @@ class IPPCompanyCurrency extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Currency name (Output only)
+                                Description: Currency name (Output
+                                only)
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -62,7 +67,10 @@ class IPPCompanyCurrency extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Indicates whether this currency is active in the company or not. Inactive Currency may be hidden from most display purposes and may not be used on financial transactions.
+                                Description: Indicates whether this
+                                currency is active in the company or not. Inactive Currency may
+                                be hidden from most display purposes and may not be used on
+                                financial transactions.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -72,7 +80,8 @@ class IPPCompanyCurrency extends IPPIntuitEntity
      */
     public $Active;
     /**
-     * @Definition Internal use only: extension place holder for Company Currency
+     * @Definition Internal use only: extension place holder for
+                                Company Currency
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPCompanyInfo.php
+++ b/src/Data/IPPCompanyInfo.php
@@ -20,20 +20,20 @@ class IPPCompanyInfo extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCompanyInfo', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCompanyInfo', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCompanyInfo', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCompanyInfo', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL
@@ -48,6 +48,7 @@ class IPPCompanyInfo extends IPPIntuitEntity
     public $CompanyName;
     /**
      * @Definition LegalName if different from the CompanyName
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -57,6 +58,7 @@ class IPPCompanyInfo extends IPPIntuitEntity
     public $LegalName;
     /**
      * @Definition Company Address as described in preference
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -65,7 +67,9 @@ class IPPCompanyInfo extends IPPIntuitEntity
      */
     public $CompanyAddr;
     /**
-     * @Definition Address of the company as given to th customer, sometimes the address given to the customer mail address is different from Company address
+     * @Definition Address of the company as given to th customer,
+                                sometimes the address given to the customer mail address is
+                                different from Company address
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -74,7 +78,8 @@ class IPPCompanyInfo extends IPPIntuitEntity
      */
     public $CustomerCommunicationAddr;
     /**
-     * @Definition Legal Address given to the government for any government communication
+     * @Definition Legal Address given to the government for any
+                                government communication
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -92,7 +97,9 @@ class IPPCompanyInfo extends IPPIntuitEntity
      */
     public $CompanyEmailAddr;
     /**
-     * @Definition Email Address published to customer for communication if different from CompanyEmailAddress
+     * @Definition Email Address published to customer for
+                                communication if different from CompanyEmailAddress
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -121,7 +128,9 @@ class IPPCompanyInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: List of ContactInfo entities of any contact info type. The ContactInfo Type values are defined in the ContactTypeEnum.
+                                Description: List of ContactInfo
+                                entities of any contact info type. The ContactInfo Type values
+                                are defined in the ContactTypeEnum.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -134,7 +143,8 @@ class IPPCompanyInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: QuickBooks company file name.[br /]Data Services max. length: 512 characters.
+                                Description: QuickBooks company
+                                file name.[br /]Data Services max. length: 512 characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -146,7 +156,9 @@ class IPPCompanyInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: QB software flavor being used on the file on the PC.[br /]Data Services max. length: 512 characters.
+                                Description: QB software flavor
+                                being used on the file on the PC.[br /]Data Services max.
+                                length: 512 characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -170,7 +182,10 @@ class IPPCompanyInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: IAM or QBN admin users id sequence number to group many external realms for this user under his id number.[br /]Data Services max. length: 512 characters.
+                                Description: IAM or QBN admin users
+                                id sequence number to group many external realms for this user
+                                under his id number.[br /]Data Services max. length: 512
+                                characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -182,7 +197,8 @@ class IPPCompanyInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: IAM or QBN admin users email.[br /]Data Services max. length: 100 characters.
+                                Description: IAM or QBN admin users
+                                email.[br /]Data Services max. length: 100 characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -242,7 +258,11 @@ class IPPCompanyInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: QuickBooks company file latest version. The format reports the major release in the first number, the minor release in the second number (always a zero), the release update (slipstream or "R") in the third number, and the build number in the final number.[br /]Max. length: 512 characters.
+                                Description: QuickBooks company file latest version. The format reports the
+                                major release in the first number, the minor release in the
+                                second number (always a zero), the release update (slipstream or
+                                "R") in the third number, and the build number in the final
+                                number.[br /]Max. length: 512 characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -254,7 +274,8 @@ class IPPCompanyInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Country name to which the company belongs for fiancial calculations.
+                                Description: Country name to which the company belongs for fiancial
+                                calculations.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -351,8 +372,8 @@ class IPPCompanyInfo extends IPPIntuitEntity
     public $LastImportedTime;
     /**
      * @Definition
-                                      Product: QBW
-                                      Description: Specifies last sync time.
+                                Product: QBW
+                                Description: Specifies last sync time.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -364,6 +385,7 @@ class IPPCompanyInfo extends IPPIntuitEntity
     public $LastSyncTime;
     /**
      * @Definition Comma separated list of languages
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -373,6 +395,7 @@ class IPPCompanyInfo extends IPPIntuitEntity
     public $SupportedLanguages;
     /**
      * @Definition Default time zone for the company
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -381,7 +404,8 @@ class IPPCompanyInfo extends IPPIntuitEntity
      */
     public $DefaultTimeZone;
     /**
-     * @Definition Specifies if the company support multibyte or not
+     * @Definition Specifies if the company support multibyte or
+                                not
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -390,7 +414,9 @@ class IPPCompanyInfo extends IPPIntuitEntity
      */
     public $MultiByteCharsSupported;
     /**
-     * @Definition Any other preference not covered in base is covered as name value pair, for detailed explanation look at the document
+     * @Definition Any other preference not covered in base is
+                                covered as name value pair, for detailed explanation look at the
+                                document
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPContactInfo.php
+++ b/src/Data/IPPContactInfo.php
@@ -23,20 +23,20 @@ class IPPContactInfo
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPContactInfo', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPContactInfo', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPContactInfo', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPContactInfo', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPContactTypeEnum.php
+++ b/src/Data/IPPContactTypeEnum.php
@@ -23,22 +23,22 @@ class IPPContactTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPContactTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPContactTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPContactTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPContactTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPContactTypeEnum

--- a/src/Data/IPPCreditCardPayment.php
+++ b/src/Data/IPPCreditCardPayment.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPCreditCardPayment
  * @xmlDefinition
                 Product: ALL
-                Description: Information about a payment received by credit card.
+                Description: Information about a
+                payment received by credit card.
 
  */
 class IPPCreditCardPayment
@@ -23,20 +24,20 @@ class IPPCreditCardPayment
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCreditCardPayment', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCreditCardPayment', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCreditCardPayment', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCreditCardPayment', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPCreditCardPurchase.php
+++ b/src/Data/IPPCreditCardPurchase.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType
  * @xmlName IPPCreditCardPurchase
  * @var IPPCreditCardPurchase
- * @xmlDefinition Financial Transaction information that pertains to the entire Check.
+ * @xmlDefinition Financial Transaction information that pertains to
+                the entire Check.
  */
 class IPPCreditCardPurchase
 {
@@ -20,20 +21,20 @@ class IPPCreditCardPurchase
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCreditCardPurchase', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCreditCardPurchase', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCreditCardPurchase', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCreditCardPurchase', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -43,7 +44,9 @@ class IPPCreditCardPurchase
      */
     public $AccountRef;
     /**
-     * @Definition  If false or null it represents a CreditCard charge expense, true represent Credit (money-in or returned)
+     * @Definition  If false or null it represents a CreditCard
+                        charge expense, true represent Credit (money-in or returned)
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPCreditCardTypeEnum.php
+++ b/src/Data/IPPCreditCardTypeEnum.php
@@ -23,22 +23,22 @@ class IPPCreditCardTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCreditCardTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCreditCardTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCreditCardTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCreditCardTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPCreditCardTypeEnum

--- a/src/Data/IPPCreditChargeInfo.php
+++ b/src/Data/IPPCreditChargeInfo.php
@@ -23,20 +23,20 @@ class IPPCreditChargeInfo
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCreditChargeInfo', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCreditChargeInfo', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCreditChargeInfo', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCreditChargeInfo', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPCreditChargeResponse.php
+++ b/src/Data/IPPCreditChargeResponse.php
@@ -23,20 +23,20 @@ class IPPCreditChargeResponse
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCreditChargeResponse', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCreditChargeResponse', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCreditChargeResponse', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCreditChargeResponse', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: Not used now

--- a/src/Data/IPPCreditMemo.php
+++ b/src/Data/IPPCreditMemo.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType SalesTransaction
  * @xmlName IPPCreditMemo
  * @var IPPCreditMemo
- * @xmlDefinition Financial transaction representing a refund (or credit) of payment or part of a payment for goods or services that have been sold.
+ * @xmlDefinition Financial transaction representing a refund (or
+                credit) of payment or part of a payment for goods or services that
+                have been sold.
  */
 class IPPCreditMemo extends IPPSalesTransaction
 {
@@ -20,23 +22,25 @@ class IPPCreditMemo extends IPPSalesTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCreditMemo', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCreditMemo', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCreditMemo', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCreditMemo', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition Indicates the total credit amount still available to apply towards the payment.
-                                [b]QuickBooks Notes[/b][br /]
+     * @Definition Indicates the total credit amount still
+                                available to apply towards the payment.
+                                [b]QuickBooks
+                                Notes[/b][br /]
                                 Non QB-writable.
 
      * @xmlType element
@@ -47,7 +51,8 @@ class IPPCreditMemo extends IPPSalesTransaction
      */
     public $RemainingCredit;
     /**
-     * @Definition Internal use only: extension place holder for CreditMemo
+     * @Definition Internal use only: extension place holder for
+                                CreditMemo
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPCurrency.php
+++ b/src/Data/IPPCurrency.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType IntuitEntity
  * @xmlName IPPCurrency
  * @var IPPCurrency
- * @xmlDefinition Describes the properties of currencies defined in QuickBooks. QuickBooks supports the world's common currencies.
+ * @xmlDefinition Describes the properties of currencies defined in
+                QuickBooks. QuickBooks supports the world's common currencies.
+
  */
 class IPPCurrency extends IPPIntuitEntity
 {
@@ -20,25 +22,26 @@ class IPPCurrency extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCurrency', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCurrency', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCurrency', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCurrency', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition Currency name.
                                 Length Restriction:
                                 QBO: 15
-                                QBW: 1024
+                                QBW:
+                                1024
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -48,9 +51,12 @@ class IPPCurrency extends IPPIntuitEntity
      */
     public $Name;
     /**
-     * @Definition Whether or not active inactive Currency may be hidden from most display purposes and may not be used on financial transactions.
+     * @Definition Whether or not active inactive Currency may be
+                                hidden from most display purposes and may not be used on
+                                financial transactions.
                                 [b][i]QuickBooks Notes[/i][/b] [br /]
-                                Inactive Currencies are not used when downloading the exchange rates.
+                                Inactive Currencies are not used when downloading the exchange
+                                rates.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -60,9 +66,11 @@ class IPPCurrency extends IPPIntuitEntity
      */
     public $Active;
     /**
-     * @Definition Currency universal 3-letter code, like USD, CAD, EUR, etc.
+     * @Definition Currency universal 3-letter code, like USD,
+                                CAD, EUR, etc.
                                 [b][i]QuickBooks Notes[/i][/b] [br /]
-                                Required for the create operation. [br /]
+                                Required for
+                                the create operation. [br /]
                                 Max Length: 3
 
      * @xmlType element
@@ -73,9 +81,11 @@ class IPPCurrency extends IPPIntuitEntity
      */
     public $Code;
     /**
-     * @Definition "Thousand separator" character, used for the display purpose.
+     * @Definition "Thousand separator" character, used for the
+                                display purpose.
                                 [b][i]QuickBooks Notes[/i][/b] [br /]
-                                Max Length: 1
+                                Max Length:
+                                1
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -85,7 +95,8 @@ class IPPCurrency extends IPPIntuitEntity
      */
     public $Separator;
     /**
-     * @Definition Specifies how to present the value, used for the display purpose for example, ##,###,### or #,##,##,###
+     * @Definition Specifies how to present the value, used for
+                                the display purpose for example, ##,###,### or #,##,##,###
                                 [b][i]QuickBooks Notes[/i][/b] [br /]
                                 Max Length: 32
 
@@ -97,7 +108,8 @@ class IPPCurrency extends IPPIntuitEntity
      */
     public $Format;
     /**
-     * @Definition Specifies how many decimal places can be shown. Usually there will be 2, or 0 for currencies without "cents".
+     * @Definition Specifies how many decimal places can be shown.
+                                Usually there will be 2, or 0 for currencies without "cents".
                                 [b][i]QuickBooks Notes[/i][/b] [br /]
                                 Max Length: 1
 
@@ -109,7 +121,8 @@ class IPPCurrency extends IPPIntuitEntity
      */
     public $DecimalPlaces;
     /**
-     * @Definition Used for display purpose, can be a comma or a period.
+     * @Definition Used for display purpose, can be a comma or a
+                                period.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -127,7 +140,8 @@ class IPPCurrency extends IPPIntuitEntity
      */
     public $Symbol;
     /**
-     * @Definition Used for display purpose to specify where to show the Currency Symbol.
+     * @Definition Used for display purpose to specify where to
+                                show the Currency Symbol.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -138,8 +152,10 @@ class IPPCurrency extends IPPIntuitEntity
     /**
      * @Definition
                                 [b][i]QuickBooks Notes[/i][/b] [br /]
-                                QuickBooks predefines the most common world currencies, however it does allow the user to define the new one.
-                                The user-defined currency however cannot have the exchange rates downloaded.
+                                QuickBooks predefines the most common world currencies, however
+                                it does allow the user to define the new one.
+                                The user-defined
+                                currency however cannot have the exchange rates downloaded.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -165,7 +181,8 @@ class IPPCurrency extends IPPIntuitEntity
      */
     public $AsOfDate;
     /**
-     * @Definition Internal use only: extension place holder for Currency
+     * @Definition Internal use only: extension place holder for
+                                Currency
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPCurrencyPrefs.php
+++ b/src/Data/IPPCurrencyPrefs.php
@@ -19,24 +19,25 @@ class IPPCurrencyPrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCurrencyPrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCurrencyPrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCurrencyPrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCurrencyPrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: Multicurrency enabled for this company
+                        Description: Multicurrency enabled
+                        for this company
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -48,7 +49,8 @@ class IPPCurrencyPrefs
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the Home currency of the company
+                        Description: Reference to the Home
+                        currency of the company
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPCustomField.php
+++ b/src/Data/IPPCustomField.php
@@ -23,20 +23,20 @@ class IPPCustomField
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCustomField', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCustomField', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCustomField', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCustomField', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPCustomFieldDefinition.php
+++ b/src/Data/IPPCustomFieldDefinition.php
@@ -23,20 +23,20 @@ class IPPCustomFieldDefinition extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCustomFieldDefinition', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCustomFieldDefinition', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCustomFieldDefinition', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCustomFieldDefinition', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL

--- a/src/Data/IPPCustomFieldTypeEnum.php
+++ b/src/Data/IPPCustomFieldTypeEnum.php
@@ -23,22 +23,22 @@ class IPPCustomFieldTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCustomFieldTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCustomFieldTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCustomFieldTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCustomFieldTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPCustomFieldTypeEnum

--- a/src/Data/IPPCustomer.php
+++ b/src/Data/IPPCustomer.php
@@ -25,20 +25,20 @@ class IPPCustomer extends IPPNameBase
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCustomer', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCustomer', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCustomer', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCustomer', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBO only
@@ -189,7 +189,7 @@ class IPPCustomer extends IPPNameBase
     public $Level;
     /**
      * @Definition
-                                Product: QBW
+                                Product: ALL
                                 Description: Reference to a CustomerType associated with the Customer.
 
      * @xmlType element
@@ -494,4 +494,30 @@ class IPPCustomer extends IPPNameBase
      * @var string
      */
     public $PrimaryTaxIdentifier;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: Specifies tax exemption reason to be associated with Customer
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlMaxOccurs 1
+     * @xmlName TaxExemptionReasonId
+     * @var string
+     */
+    public $TaxExemptionReasonId;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: Specifies whether this customer is a project.
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlMaxOccurs 1
+     * @xmlName IsProject
+     * @var boolean
+     */
+    public $IsProject;
 } // end class IPPCustomer

--- a/src/Data/IPPCustomerMsg.php
+++ b/src/Data/IPPCustomerMsg.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType IntuitEntity
  * @xmlName IPPCustomerMsg
  * @var IPPCustomerMsg
- * @xmlDefinition A standard message to a customer that can be included at the bottom of a sales form.
+ * @xmlDefinition A standard message to a customer that can be
+                included at the bottom of a sales form.
 
  */
 class IPPCustomerMsg extends IPPIntuitEntity
@@ -21,20 +22,20 @@ class IPPCustomerMsg extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCustomerMsg', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCustomerMsg', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCustomerMsg', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCustomerMsg', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition Contains the message to a customer.[br /]
                                 Length Restriction:
@@ -49,7 +50,9 @@ class IPPCustomerMsg extends IPPIntuitEntity
      */
     public $Name;
     /**
-     * @Definition Whether or not active inactive customer message may be hidden from most display purposes and may not be used on financial transactions.
+     * @Definition Whether or not active inactive customer message
+                                may be hidden from most display purposes and may not be used on
+                                financial transactions.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -58,7 +61,8 @@ class IPPCustomerMsg extends IPPIntuitEntity
      */
     public $Active;
     /**
-     * @Definition Internal use only: extension place holder for CustomerMsg
+     * @Definition Internal use only: extension place holder for
+                                CustomerMsg
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPCustomerType.php
+++ b/src/Data/IPPCustomerType.php
@@ -23,20 +23,20 @@ class IPPCustomerType extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCustomerType', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCustomerType', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCustomerType', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCustomerType', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBW

--- a/src/Data/IPPCustomerTypeEnum.php
+++ b/src/Data/IPPCustomerTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPCustomerTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of customer types in QuickBooks.
+                Description: Enumeration of customer
+                types in QuickBooks.
 
  */
 class IPPCustomerTypeEnum
@@ -23,22 +24,22 @@ class IPPCustomerTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPCustomerTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPCustomerTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPCustomerTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCustomerTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPCustomerTypeEnum

--- a/src/Data/IPPDateMacro.php
+++ b/src/Data/IPPDateMacro.php
@@ -11,31 +11,35 @@ namespace QuickBooksOnline\API\Data;
 class IPPDateMacro
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDateMacro', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDateMacro', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDateMacro', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDateMacro', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
+    }//end __construct()
+
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
-} // end class IPPDateMacro
+    public $value;
+}//end class
+
+ // end class IPPDateMacro

--- a/src/Data/IPPDateTypeCustomFieldDefinition.php
+++ b/src/Data/IPPDateTypeCustomFieldDefinition.php
@@ -23,20 +23,20 @@ class IPPDateTypeCustomFieldDefinition extends IPPCustomFieldDefinition
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDateTypeCustomFieldDefinition', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDateTypeCustomFieldDefinition', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDateTypeCustomFieldDefinition', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDateTypeCustomFieldDefinition', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL

--- a/src/Data/IPPDayOfWeekEnum.php
+++ b/src/Data/IPPDayOfWeekEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPDayOfWeekEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of the days of the week.
+                Description: Enumeration of the days of
+                the week.
 
  */
 class IPPDayOfWeekEnum
@@ -23,22 +24,22 @@ class IPPDayOfWeekEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDayOfWeekEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDayOfWeekEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDayOfWeekEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDayOfWeekEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPDayOfWeekEnum

--- a/src/Data/IPPDeliveryErrorTypeEnum.php
+++ b/src/Data/IPPDeliveryErrorTypeEnum.php
@@ -23,22 +23,22 @@ class IPPDeliveryErrorTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDeliveryErrorTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDeliveryErrorTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDeliveryErrorTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDeliveryErrorTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPDeliveryErrorTypeEnum

--- a/src/Data/IPPDeliveryTypeEnum.php
+++ b/src/Data/IPPDeliveryTypeEnum.php
@@ -23,22 +23,22 @@ class IPPDeliveryTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDeliveryTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDeliveryTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDeliveryTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDeliveryTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPDeliveryTypeEnum

--- a/src/Data/IPPDepartment.php
+++ b/src/Data/IPPDepartment.php
@@ -6,7 +6,11 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType IntuitEntity
  * @xmlName IPPDepartment
  * @var IPPDepartment
- * @xmlDefinition Department provide a way to track different segments of the business, and to break down the income and expenses for each segment. Department can apply to all transactions, so they're not tied to a particular client or project.
+ * @xmlDefinition Department provide a way to track different
+                segments of the business, and to break down the income and expenses
+                for each segment. Department can apply to all transactions, so
+                they're not tied to a particular client or project.
+
  */
 class IPPDepartment extends IPPIntuitEntity
 {
@@ -20,20 +24,20 @@ class IPPDepartment extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDepartment', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDepartment', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDepartment', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDepartment', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition User recognizable name for the Class.[br /]
                                 Length Restriction:
@@ -48,7 +52,9 @@ class IPPDepartment extends IPPIntuitEntity
      */
     public $Name;
     /**
-     * @Definition  Specifies the Department is a SubDepartment or Not. True if subdepartment, false or null if it is top-level department
+     * @Definition  Specifies the Department is a SubDepartment or
+                                Not. True if subdepartment, false or null if it is top-level
+                                department
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -59,6 +65,7 @@ class IPPDepartment extends IPPIntuitEntity
     public $SubDepartment;
     /**
      * @Definition Reference to parent class entity
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -69,7 +76,11 @@ class IPPDepartment extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Output Only. Fully qualified name of the entity. The fully qualified name prepends the topmost parent, followed by each sub element separated by colons. Takes the form of: [br /] Parent:Location1:SubLocation1:SubLocation2
+                                Description: Output Only. Fully
+                                qualified name of the entity. The fully qualified name prepends
+                                the topmost parent, followed by each sub element separated by
+                                colons. Takes the form of: [br /]
+                                Parent:Location1:SubLocation1:SubLocation2
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -79,7 +90,9 @@ class IPPDepartment extends IPPIntuitEntity
      */
     public $FullyQualifiedName;
     /**
-     * @Definition Whether or not active inactive classes may be hidden from most display purposes and may not be used on financial transactions
+     * @Definition Whether or not active inactive classes may be
+                                hidden from most display purposes and may not be used on
+                                financial transactions
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -88,7 +101,8 @@ class IPPDepartment extends IPPIntuitEntity
      */
     public $Active;
     /**
-     * @Definition Internal use only: extension place holder for DepartmentEx extensible element
+     * @Definition Internal use only: extension place holder for
+                                DepartmentEx extensible element
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPDeposit.php
+++ b/src/Data/IPPDeposit.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType Transaction
  * @xmlName IPPDeposit
  * @var IPPDeposit
- * @xmlDefinition Transaction recording a payment from the customer held in the Undeposited Funds account into the Bank account.
+ * @xmlDefinition Transaction recording a payment from the customer
+                held in the Undeposited Funds account into the Bank account.
+
  */
 class IPPDeposit extends IPPTransaction
 {
@@ -20,24 +22,26 @@ class IPPDeposit extends IPPTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDepartment', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDepartment', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDeposit', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDeposit', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition DepositToAccountReferenceGroup Identifies the Asset Account (bank account) to be used for this Deposit.
+     * @Definition DepositToAccountReferenceGroup Identifies the
+                                Asset Account (bank account) to be used for this Deposit.
                                 [b]QuickBooks Notes[/b][br /]
-                                Required for the create operation. [br /]
+                                Required for the create operation.
+                                [br /]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -57,7 +61,9 @@ class IPPDeposit extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Indicates the GlobalTax model if the model inclusive of tax, exclusive of taxes or not applicable
+                                Description: Indicates the
+                                GlobalTax model if the model inclusive of tax, exclusive of
+                                taxes or not applicable
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -68,7 +74,8 @@ class IPPDeposit extends IPPTransaction
     public $GlobalTaxCalculation;
     /**
      * @Definition Total amount of Deposit.
-                                [b]QuickBooks Notes[/b][br /]
+                                [b]QuickBooks
+                                Notes[/b][br /]
                                 Non QB-writable.
 
      * @xmlType element
@@ -81,7 +88,12 @@ class IPPDeposit extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: Total amount of the transaction in the home currency for multi-currency enabled companies. Single currency companies will not have this field. Includes the total of all the charges, allowances and taxes. Calculated by QuickBooks business logic. Cannot be written to QuickBooks.
+                                Description: Total amount of the
+                                transaction in the home currency for multi-currency enabled
+                                companies. Single currency companies will not have this field.
+                                Includes the total of all the charges, allowances and taxes.
+                                Calculated by QuickBooks business logic. Cannot be written to
+                                QuickBooks.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -91,7 +103,8 @@ class IPPDeposit extends IPPTransaction
      */
     public $HomeTotalAmt;
     /**
-     * @Definition Internal use only: extension place holder for Deposit
+     * @Definition Internal use only: extension place holder for
+                                Deposit
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPDepositLineDetail.php
+++ b/src/Data/IPPDepositLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPDepositLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: Deposit detail for a transaction line.
+                Description: Deposit detail for a
+                transaction line.
 
  */
 class IPPDepositLineDetail
@@ -23,24 +24,25 @@ class IPPDepositLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDepositLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDepositLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDepositLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDepositLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: Information about the Customer or Job associated with the deposit.
+                        Description: Information about the
+                        Customer or Job associated with the deposit.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +54,8 @@ class IPPDepositLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the Class for the deposit.
+                        Description: Reference to the Class
+                        for the deposit.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +67,8 @@ class IPPDepositLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to an Expense account associated with the service/non-sellable item billing.
+                        Description: Reference to an Expense
+                        account associated with the service/non-sellable item billing.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +80,8 @@ class IPPDepositLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the PaymentMethod for the deposit.
+                        Description: Reference to the
+                        PaymentMethod for the deposit.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -88,7 +93,8 @@ class IPPDepositLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Check number for the desposit.
+                        Description: Check number for the
+                        desposit.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -100,7 +106,8 @@ class IPPDepositLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Type of the payment transaction. For information purposes only.[br /]
+                        Description: Type of the payment
+                        transaction. For information purposes only.[br /]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -112,7 +119,8 @@ class IPPDepositLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: Sales/Purchase tax code. For Non US/CA Companies
+                        Description: Sales/Purchase tax code.
+                        For Non US/CA Companies
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -124,7 +132,8 @@ class IPPDepositLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: Indicates whether the tax applicable on the line is sales or purchase
+                        Description: Indicates whether the
+                        tax applicable on the line is sales or purchase
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -136,7 +145,8 @@ class IPPDepositLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Internal use only: extension place holder for DepositDetail
+                        Description: Internal use only:
+                        extension place holder for DepositDetail
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPDescriptionLineDetail.php
+++ b/src/Data/IPPDescriptionLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPDescriptionLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: Information about Description.
+                Description: Information about
+                Description.
 
  */
 class IPPDescriptionLineDetail
@@ -23,24 +24,25 @@ class IPPDescriptionLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDescriptionLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDescriptionLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDescriptionLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDescriptionLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: Date when the service is performed.
+                        Description: Date when the service is
+                        performed.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,10 +54,15 @@ class IPPDescriptionLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: Reference to the TaxCode for description only line.
-                        Though it appears that TaxCode is not applicable to DescriptionOnlyLine as there is no amount associated with it, UK and Canada model
-                        seems to associate the notion of TaxCode even for just a description line
-                        Marking this as QBO only at this time but it looks like applicable for QB in general
+                        Description: Reference to the TaxCode
+                        for description only line.
+                        Though it appears that TaxCode is not
+                        applicable to DescriptionOnlyLine as there is no amount associated
+                        with it, UK and Canada model
+                        seems to associate the notion of
+                        TaxCode even for just a description line
+                        Marking this as QBO only
+                        at this time but it looks like applicable for QB in general
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -67,7 +74,8 @@ class IPPDescriptionLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Internal use only: extension place holder for DescriptionLineDetail
+                        Description: Internal use only:
+                        extension place holder for DescriptionLineDetail
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPDesktopEntityTypeEnum.php
+++ b/src/Data/IPPDesktopEntityTypeEnum.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType string
  * @xmlName IPPDesktopEntityTypeEnum
  * @var IPPDesktopEntityTypeEnum
- * @xmlDefinition Enumeration of Desktop Entity Type For ThirdPartyAppId Migration
+ * @xmlDefinition Enumeration of Desktop Entity Type For
+                ThirdPartyAppId Migration
  */
 class IPPDesktopEntityTypeEnum
 {
@@ -20,22 +21,22 @@ class IPPDesktopEntityTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDesktopEntityTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDesktopEntityTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDesktopEntityTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDesktopEntityTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPDesktopEntityTypeEnum

--- a/src/Data/IPPDiscountLineDetail.php
+++ b/src/Data/IPPDiscountLineDetail.php
@@ -8,9 +8,11 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPDiscountLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: Discount detail for a transaction line.
+                Description: Discount detail for a
+                transaction line.
                 Product: QBO
-                Description: Discount detail representing the total discount on a transaction.
+                Description: Discount detail
+                representing the total discount on a transaction.
 
  */
 class IPPDiscountLineDetail extends IPPDiscountOverride
@@ -25,24 +27,25 @@ class IPPDiscountLineDetail extends IPPDiscountOverride
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDiscountLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDiscountLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDiscountLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDiscountLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL
-                                Description: Date when the service is performed.
+                                Description: Date when the service
+                                is performed.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -54,7 +57,8 @@ class IPPDiscountLineDetail extends IPPDiscountOverride
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the Class for the discount.
+                                Description: Reference to the Class
+                                for the discount.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -66,7 +70,8 @@ class IPPDiscountLineDetail extends IPPDiscountOverride
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the TaxCode for the discount.
+                                Description: Reference to the
+                                TaxCode for the discount.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -78,7 +83,8 @@ class IPPDiscountLineDetail extends IPPDiscountOverride
     /**
      * @Definition
                                 Product: ALL
-                                Description: Internal use only: extension place holder for DiscountDetail
+                                Description: Internal use only:
+                                extension place holder for DiscountDetail
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPDiscountOverride.php
+++ b/src/Data/IPPDiscountOverride.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPDiscountOverride
  * @xmlDefinition
                     Product: ALL
-                    Description: Optional amount by which the amount due on the referenced transaction is being reduced.
+                    Description: Optional amount by which
+                    the amount due on the referenced transaction is being reduced.
 
  */
 class IPPDiscountOverride
@@ -23,24 +24,26 @@ class IPPDiscountOverride
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDiscountOverride', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDiscountOverride', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDiscountOverride', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDiscountOverride', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: Discount used in calculating and applying the discount on the sales transaction paid.
+                        Description: Discount used in
+                        calculating and applying the discount on the sales transaction
+                        paid.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +55,8 @@ class IPPDiscountOverride
     /**
      * @Definition
                         Product: ALL
-                        Description: True if the discount is a percentage; null or false if discount based on amount.
+                        Description: True if the discount is
+                        a percentage; null or false if discount based on amount.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +68,9 @@ class IPPDiscountOverride
     /**
      * @Definition
                         Product: ALL
-                        Description: Percentage by which the amount due is reduced, from 0% to 100%. To enter a discount of 8.5% use 8.5, not 0.085.
+                        Description: Percentage by which the
+                        amount due is reduced, from 0% to 100%. To enter a discount of
+                        8.5% use 8.5, not 0.085.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +82,8 @@ class IPPDiscountOverride
     /**
      * @Definition
                         Product: ALL
-                        Description: Income account used to track discounts received from vendors on purchases.
+                        Description: Income account used to
+                        track discounts received from vendors on purchases.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPDiscountTypeEnum.php
+++ b/src/Data/IPPDiscountTypeEnum.php
@@ -23,22 +23,22 @@ class IPPDiscountTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPDiscountTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPDiscountTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPDiscountTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPDiscountTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPDiscountTypeEnum

--- a/src/Data/IPPETransactionEnabledStatusEnum.php
+++ b/src/Data/IPPETransactionEnabledStatusEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPETransactionEnabledStatusEnum
  * @xmlDefinition
                 Product: QBO
-                Description: Enumeration of eTransaction prefs status.
+                Description: Enumeration of
+                eTransaction prefs status.
 
  */
 class IPPETransactionEnabledStatusEnum
@@ -23,22 +24,22 @@ class IPPETransactionEnabledStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPETransactionEnabledStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPETransactionEnabledStatusEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPETransactionEnabledStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPETransactionEnabledStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPETransactionEnabledStatusEnum

--- a/src/Data/IPPETransactionStatusEnum.php
+++ b/src/Data/IPPETransactionStatusEnum.php
@@ -8,7 +8,11 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPETransactionStatusEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of eTransaction status values. The statuses (Sent, Viewed, Paid, Delivery Error, Updated, Sent With ICN Error) are used by QBO eInvoicing. The rest statuses are to be used for Tradeshift Integration
+                Description: Enumeration of
+                eTransaction status values. The statuses (Sent, Viewed, Paid,
+                Delivery Error, Updated, Sent With ICN Error) are used by QBO
+                eInvoicing. The rest statuses are to be used for Tradeshift
+                Integration
 
  */
 class IPPETransactionStatusEnum
@@ -23,22 +27,22 @@ class IPPETransactionStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPETransactionStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPETransactionStatusEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPETransactionStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPETransactionStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPETransactionStatusEnum

--- a/src/Data/IPPEffectiveTaxRate.php
+++ b/src/Data/IPPEffectiveTaxRate.php
@@ -23,20 +23,20 @@ class IPPEffectiveTaxRate
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEffectiveTaxRate', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEffectiveTaxRate', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEffectiveTaxRate', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEffectiveTaxRate', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
@@ -52,7 +52,8 @@ class IPPEffectiveTaxRate
     /**
      * @Definition
                         Product: QBO
-                        Description: Effective starting date for which this taxrate is applicable
+                        Description: Effective starting date
+                        for which this taxrate is applicable
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +65,8 @@ class IPPEffectiveTaxRate
     /**
      * @Definition
                         Product: QBO
-                        Description: End date of this taxrate applicability
+                        Description: End date of this taxrate
+                        applicability
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +78,8 @@ class IPPEffectiveTaxRate
     /**
      * @Definition
                         Product: ALL
-                        Description: Internal use only: extension place holder for TaxLine.
+                        Description: Internal use only:
+                        extension place holder for TaxLine.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPEmailAddress.php
+++ b/src/Data/IPPEmailAddress.php
@@ -23,20 +23,20 @@ class IPPEmailAddress
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEmailAddress', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEmailAddress', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEmailAddress', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEmailAddress', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: QBW

--- a/src/Data/IPPEmailAddressTypeEnum.php
+++ b/src/Data/IPPEmailAddressTypeEnum.php
@@ -23,22 +23,22 @@ class IPPEmailAddressTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEmailAddressTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEmailAddressTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEmailAddressTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEmailAddressTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPEmailAddressTypeEnum

--- a/src/Data/IPPEmailDeliveryInfo.php
+++ b/src/Data/IPPEmailDeliveryInfo.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPEmailDeliveryInfo
  * @xmlDefinition
                 Product: QBO
-                Description: Specifies various fields required for emailing different transaction
+                Description: Specifies various fields
+                required for emailing different transaction
 
  */
 class IPPEmailDeliveryInfo extends IPPIntuitEntity
@@ -23,24 +24,25 @@ class IPPEmailDeliveryInfo extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEmailDeliveryInfo', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEmailDeliveryInfo', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEmailDeliveryInfo', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEmailDeliveryInfo', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBO
-                                Description: Email address of recipients. Multiple email address seperated with comma.
+                                Description: Email address of
+                                recipients. Multiple email address seperated with comma.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +54,34 @@ class IPPEmailDeliveryInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Custom Email subject and message to be used for this email.
+                                Description: Cc email address of
+                                recipients. Multiple email address seperated with comma.
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName DeliveryAddressCc
+     * @var com\intuit\schema\finance\v3\IPPEmailAddress
+     */
+    public $DeliveryAddressCc;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: Bcc email address of
+                                recipients. Multiple email address seperated with comma.
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName DeliveryAddressBcc
+     * @var com\intuit\schema\finance\v3\IPPEmailAddress
+     */
+    public $DeliveryAddressBcc;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: Custom Email subject
+                                and message to be used for this email.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +93,8 @@ class IPPEmailDeliveryInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Specifies whether online payment should be enabled for this transaction
+                                Description: Specifies whether
+                                online payment should be enabled for this transaction
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +106,9 @@ class IPPEmailDeliveryInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Specifies whether customer is allowed to use eInvoicing(online payment -credit card) to pay the Invoice
+                                Description: Specifies whether
+                                customer is allowed to use eInvoicing(online payment -credit
+                                card) to pay the Invoice
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -88,7 +120,9 @@ class IPPEmailDeliveryInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Specifies whether customer is allowed to use eInvoicing(online payment -bank or ach) to pay the Invoice
+                                Description: Specifies whether
+                                customer is allowed to use eInvoicing(online payment -bank or
+                                ach) to pay the Invoice
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -100,7 +134,9 @@ class IPPEmailDeliveryInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Delivery information like DeliveryTime, DeliveryType and DeliveryErrorType (if applicable)
+                                Description: Delivery information
+                                like DeliveryTime, DeliveryType and DeliveryErrorType (if
+                                applicable)
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -112,7 +148,9 @@ class IPPEmailDeliveryInfo extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Specifies ETransaction status of this transaction. Applicable if ETransaction is enabled and this transaction is a ETransaction.
+                                Description: Specifies ETransaction
+                                status of this transaction. Applicable if ETransaction is
+                                enabled and this transaction is a ETransaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPEmailMessage.php
+++ b/src/Data/IPPEmailMessage.php
@@ -23,20 +23,20 @@ class IPPEmailMessage
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEmailMessage', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEmailMessage', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEmailMessage', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEmailMessage', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: QBO

--- a/src/Data/IPPEmailMessagesPrefs.php
+++ b/src/Data/IPPEmailMessagesPrefs.php
@@ -20,22 +20,23 @@ class IPPEmailMessagesPrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEmailMessagesPrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEmailMessagesPrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEmailMessagesPrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEmailMessagesPrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition  Specifies Preferences classified as email messages are classified as Name-Value pair
+     * @Definition  Specifies Preferences classified as email
+                        messages are classified as Name-Value pair
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -48,7 +49,8 @@ class IPPEmailMessagesPrefs
     /**
      * @Definition
                         Product:QBO
-                        Default email subject and message for Invoice.
+                        Default email subject and message for
+                        Invoice.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -60,7 +62,8 @@ class IPPEmailMessagesPrefs
     /**
      * @Definition
                         Product:QBO
-                        Default email subject and message for Estimate.
+                        Default email subject and message for
+                        Estimate.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -72,7 +75,8 @@ class IPPEmailMessagesPrefs
     /**
      * @Definition
                         Product:QBO
-                        Default email subject and message for Sales receipt.
+                        Default email subject and message for
+                        Sales receipt.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -84,7 +88,8 @@ class IPPEmailMessagesPrefs
     /**
      * @Definition
                         Product:QBO
-                        Default email subject and message for Statement.
+                        Default email subject and message for
+                        Statement.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPEmailStatusEnum.php
+++ b/src/Data/IPPEmailStatusEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPEmailStatusEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of email status values.
+                Description: Enumeration of email
+                status values.
 
  */
 class IPPEmailStatusEnum
@@ -23,22 +24,22 @@ class IPPEmailStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEmailStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEmailStatusEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEmailStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEmailStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPEmailStatusEnum

--- a/src/Data/IPPEmployee.php
+++ b/src/Data/IPPEmployee.php
@@ -20,20 +20,20 @@ class IPPEmployee extends IPPNameBase
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEmployee', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEmployee', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEmployee', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEmployee', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition Specifies the Employee type. For QuickBooks Desktop the valid values are defined in the EmployeeTypeEnum.
      * @xmlType element

--- a/src/Data/IPPEmployeeTypeEnum.php
+++ b/src/Data/IPPEmployeeTypeEnum.php
@@ -23,22 +23,22 @@ class IPPEmployeeTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEmployeeTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEmployeeTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEmployeeTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEmployeeTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPEmployeeTypeEnum

--- a/src/Data/IPPEntityStatusEnum.php
+++ b/src/Data/IPPEntityStatusEnum.php
@@ -23,22 +23,22 @@ class IPPEntityStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEntityStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEntityStatusEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEntityStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEntityStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPEntityStatusEnum

--- a/src/Data/IPPEntityTypeEnum.php
+++ b/src/Data/IPPEntityTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPEntityTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of Entity types.
+                Description: Enumeration of Entity
+                types.
 
  */
 class IPPEntityTypeEnum
@@ -23,22 +24,22 @@ class IPPEntityTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEntityTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEntityTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEntityTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEntityTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPEntityTypeEnum

--- a/src/Data/IPPEntityTypeRef.php
+++ b/src/Data/IPPEntityTypeRef.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPEntityTypeRef
  * @xmlDefinition
                 Product: ALL
-                Description: Reference information for an entity.
+                Description: Reference information for
+                an entity.
 
  */
 class IPPEntityTypeRef
@@ -23,20 +24,20 @@ class IPPEntityTypeRef
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEntityTypeRef', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEntityTypeRef', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEntityTypeRef', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEntityTypeRef', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPError.php
+++ b/src/Data/IPPError.php
@@ -12,26 +12,26 @@ class IPPError
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPError', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPError', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPError', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPError', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
 
     /**

--- a/src/Data/IPPEstimate.php
+++ b/src/Data/IPPEstimate.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType SalesTransaction
  * @xmlName IPPEstimate
  * @var IPPEstimate
- * @xmlDefinition Transaction entity is the base class of all transactions
+ * @xmlDefinition Transaction entity is the base class of all
+                transactions
  */
 class IPPEstimate extends IPPSalesTransaction
 {
@@ -20,22 +21,23 @@ class IPPEstimate extends IPPSalesTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEstimate', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPEstimate', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEstimate', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEstimate', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition Date by which estimate must be accepted before invalidation.
+     * @Definition Date by which estimate must be accepted before
+                                invalidation.
                                 QBO only field.
 
      * @xmlType element
@@ -47,7 +49,8 @@ class IPPEstimate extends IPPSalesTransaction
     public $ExpirationDate;
     /**
      * @Definition Name of customer who accepted the estimate.
-                                QBO only field.
+                                QBO
+                                only field.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPEstimateStatusEnum.php
+++ b/src/Data/IPPEstimateStatusEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPEstimateStatusEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of status for an estimate.
+                Description: Enumeration of status for
+                an estimate.
 
  */
 class IPPEstimateStatusEnum
@@ -23,22 +24,22 @@ class IPPEstimateStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPEstimateStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPAccountBasedExpenseLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPEstimateStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPEstimateStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPEstimateStatusEnum

--- a/src/Data/IPPExchangeRate.php
+++ b/src/Data/IPPExchangeRate.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType IntuitEntity
  * @xmlName IPPExchangeRate
  * @var IPPExchangeRate
- * @xmlDefinition Describes properties of an exchange rate between source and target currencies.
+ * @xmlDefinition Describes properties of an exchange rate between
+                source and target currencies.
  */
 class IPPExchangeRate extends IPPIntuitEntity
 {
@@ -20,24 +21,27 @@ class IPPExchangeRate extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPExchangeRate', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPExchangeRate', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPExchangeRate', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPExchangeRate', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBO
-                                Description: Universal 3-letter code of source currency from which exchange rate is required, usually LHS of the equation. Example: 1 USD = 65 INR. Here USD would be the source currency.
+                                Description: Universal 3-letter
+                                code of source currency from which exchange rate is required,
+                                usually LHS of the equation. Example: 1 USD = 65 INR. Here USD
+                                would be the source currency.
                                 Max Length: 3
 
      * @xmlType element
@@ -50,7 +54,10 @@ class IPPExchangeRate extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Universal 3-letter currency code of target currency against which exchange rate is required, usually RHS of the equation. Usually this would be the home currency.
+                                Description: Universal 3-letter
+                                currency code of target currency against which exchange rate is
+                                required, usually RHS of the equation. Usually this would be the
+                                home currency.
                                 Max Length: 3
 
      * @xmlType element
@@ -63,7 +70,8 @@ class IPPExchangeRate extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Exchange rate to be set between these two currencies for the mentioned date.
+                                Description: Exchange rate to be
+                                set between these two currencies for the mentioned date.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -75,7 +83,8 @@ class IPPExchangeRate extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Date as on which the exchange rate needs to be set.
+                                Description: Date as on which the
+                                exchange rate needs to be set.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -85,7 +94,8 @@ class IPPExchangeRate extends IPPIntuitEntity
      */
     public $AsOfDate;
     /**
-     * @Definition Internal use only: extension place holder for Exchange Rate
+     * @Definition Internal use only: extension place holder for
+                                Exchange Rate
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPExternalKey.php
+++ b/src/Data/IPPExternalKey.php
@@ -23,22 +23,22 @@ class IPPExternalKey
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPExternalKey', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPExternalKey', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPExternalKey', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPExternalKey', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPExternalKey

--- a/src/Data/IPPFault.php
+++ b/src/Data/IPPFault.php
@@ -12,26 +12,26 @@ class IPPFault
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPFault', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPFault', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPFault', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPFault', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
 
     /**

--- a/src/Data/IPPFaultTypeEnum.php
+++ b/src/Data/IPPFaultTypeEnum.php
@@ -11,31 +11,35 @@ namespace QuickBooksOnline\API\Data;
 class IPPFaultTypeEnum
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPFaultTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPFaultTypeEnum', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPFaultTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPFaultTypeEnum', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
+    }//end __construct()
+
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
-} // end class IPPFaultTypeEnum
+    public $value;
+}//end class
+
+ // end class IPPFaultTypeEnum

--- a/src/Data/IPPFinanceChargePrefs.php
+++ b/src/Data/IPPFinanceChargePrefs.php
@@ -19,24 +19,25 @@ class IPPFinanceChargePrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPFinanceChargePrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPFinanceChargePrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPFinanceChargePrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPFinanceChargePrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product:QBW
                         Annual Interest Rate in percent
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -69,8 +70,10 @@ class IPPFinanceChargePrefs
     /**
      * @Definition
                         Product:QBW
-                        If true, the Finance Charges are calculated from the transaction date (Invoice, or Bill).[br /]
-                        If false, the Finance Charges are calculated from the due date.
+                        If true, the Finance Charges are
+                        calculated from the transaction date (Invoice, or Bill).[br /]
+                        If
+                        false, the Finance Charges are calculated from the due date.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -82,7 +85,9 @@ class IPPFinanceChargePrefs
     /**
      * @Definition
                         Product:QBW
-                        true if finance charges should apply to overdue charges, in which case the charges will be applied to the account referenced in FinChrgAccountRef
+                        true if finance charges should apply
+                        to overdue charges, in which case the charges will be applied to
+                        the account referenced in FinChrgAccountRef
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -95,7 +100,8 @@ class IPPFinanceChargePrefs
      * @Definition
                         Product:QBW
                         [b]QuickBooks Notes[/b][br /]
-                        Max Length: 31 or 159 (for a fully qualified name)
+                        Max
+                        Length: 31 or 159 (for a fully qualified name)
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPFixedAsset.php
+++ b/src/Data/IPPFixedAsset.php
@@ -6,8 +6,11 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType IntuitEntity
  * @xmlName IPPFixedAsset
  * @var IPPFixedAsset
- * @xmlDefinition An asset you do not expect to convert to cash during one year of normal operations.
-                A fixed asset is usually something that is necessary for the operation of your business, such as a truck, cash register, or computer.
+ * @xmlDefinition An asset you do not expect to convert to cash
+                during one year of normal operations.
+                A fixed asset is usually
+                something that is necessary for the operation of your business, such
+                as a truck, cash register, or computer.
 
  */
 class IPPFixedAsset extends IPPIntuitEntity
@@ -22,22 +25,23 @@ class IPPFixedAsset extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPFixedAsset', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPFixedAsset', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPFixedAsset', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPFixedAsset', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition User recognizable name for the Fixed Asset Item.[br /]
+     * @Definition User recognizable name for the Fixed Asset
+                                Item.[br /]
                                 Length Restriction:
                                 QBO: 15
                                 QBW: 1024
@@ -50,7 +54,9 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $Name;
     /**
-     * @Definition Whether or not active inactive fixed assets may be hidden from most display purposes and may not be used on financial transactions.
+     * @Definition Whether or not active inactive fixed assets may
+                                be hidden from most display purposes and may not be used on
+                                financial transactions.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -59,8 +65,10 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $Active;
     /**
-     * @Definition Specifies whether the asset is new or used. This will aid in calculating depreciation.[br /]
-                                Length Restriction:
+     * @Definition Specifies whether the asset is new or used.
+                                This will aid in calculating depreciation.[br /]
+                                Length
+                                Restriction:
                                 QBO: 15
                                 QBW: 1024
 
@@ -72,7 +80,9 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $AcquiredAs;
     /**
-     * @Definition User entered purchase description for the fixed asset which may include user entered information to further describe the details of the purchase.
+     * @Definition User entered purchase description for the fixed
+                                asset which may include user entered information to further
+                                describe the details of the purchase.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -81,7 +91,8 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $PurchaseDesc;
     /**
-     * @Definition Specifies the date the asset was purchased or acquired.[br /]
+     * @Definition Specifies the date the asset was purchased or
+                                acquired.[br /]
                                 Length Restriction:
                                 QBO: 15
                                 QBW: 1024
@@ -95,6 +106,7 @@ class IPPFixedAsset extends IPPIntuitEntity
     public $PurchaseDate;
     /**
      * @Definition Specifies the asset's purchase price.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -103,7 +115,8 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $PurchaseCost;
     /**
-     * @Definition Specifies the name of the vendor or payee from whom the asset was purchased.
+     * @Definition Specifies the name of the vendor or payee from
+                                whom the asset was purchased.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -112,8 +125,11 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $Vendor;
     /**
-     * @Definition Indicates the Fixed Asset account that tracks the current value of the asset. If the same account is used for all fixed assets, the current balance of this account will represent the current total value of the fixed assets.[br /]
-                                 [br /]
+     * @Definition Indicates the Fixed Asset account that tracks
+                                the current value of the asset. If the same account is used for
+                                all fixed assets, the current balance of this account will
+                                represent the current total value of the fixed assets.[br /]
+                                [br /]
                                 Required for the create operation. [br /]
 
      * @xmlType element
@@ -124,7 +140,9 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $AssetAccountRef;
     /**
-     * @Definition User entered sales description for the fixed asset which may include user entered information to further describe the details of the sales.
+     * @Definition User entered sales description for the fixed
+                                asset which may include user entered information to further
+                                describe the details of the sales.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -134,6 +152,7 @@ class IPPFixedAsset extends IPPIntuitEntity
     public $SalesDesc;
     /**
      * @Definition Specifies the date the asset was sold.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -142,7 +161,8 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $SalesDate;
     /**
-     * @Definition Specifies the amount for which the asset was sold.
+     * @Definition Specifies the amount for which the asset was
+                                sold.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -151,7 +171,8 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $SalesPrice;
     /**
-     * @Definition Additional expenses incurred during the sale of the asset.
+     * @Definition Additional expenses incurred during the sale of
+                                the asset.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -160,7 +181,8 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $SalesExpense;
     /**
-     * @Definition Information about where the asset is located or has been placed into service.
+     * @Definition Information about where the asset is located or
+                                has been placed into service.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -169,7 +191,8 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $Location;
     /**
-     * @Definition The purchase order number if a purchase order was used to buy the asset.
+     * @Definition The purchase order number if a purchase order
+                                was used to buy the asset.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -178,7 +201,8 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $PONumber;
     /**
-     * @Definition The serial number of the asset. For a vehicle, it can be the VIN.
+     * @Definition The serial number of the asset. For a vehicle,
+                                it can be the VIN.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -188,6 +212,7 @@ class IPPFixedAsset extends IPPIntuitEntity
     public $SerialNumber;
     /**
      * @Definition The date the warranty for the asset expires.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -196,7 +221,8 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $WarrantyExpDate;
     /**
-     * @Definition Any description of the asset, like maker, brand, and so on.
+     * @Definition Any description of the asset, like maker,
+                                brand, and so on.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -205,7 +231,9 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $Description;
     /**
-     * @Definition Notes about the asset that might help to track it properly, such as notes about repairs or upkeep.
+     * @Definition Notes about the asset that might help to track
+                                it properly, such as notes about repairs or upkeep.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -214,7 +242,8 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $Notes;
     /**
-     * @Definition QBW only: asset number. Maintained by the QB Fixed Asset Manager.
+     * @Definition QBW only: asset number. Maintained by the QB
+                                Fixed Asset Manager.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -223,7 +252,10 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $AssetNum;
     /**
-     * @Definition QBW only: The total cost of the fixed asset. This can include the cost of improvements or repairs. This amount is used to calculate depreciation. Maintained by the QB Fixed Asset Manager.
+     * @Definition QBW only: The total cost of the fixed asset.
+                                This can include the cost of improvements or repairs. This
+                                amount is used to calculate depreciation. Maintained by the QB
+                                Fixed Asset Manager.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -232,7 +264,10 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $CostBasis;
     /**
-     * @Definition QBW only: the total amount of depreciation expense since the fixed asset was acquired as of the end of the year. Maintained by the QB Fixed Asset Manager.
+     * @Definition QBW only: the total amount of depreciation
+                                expense since the fixed asset was acquired as of the end of the
+                                year. Maintained by the QB Fixed Asset Manager.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -241,7 +276,9 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $Depreciation;
     /**
-     * @Definition QBW only: the asset's cost or basis less accumulated depreciation as of the end of the year. Maintained by the QB Fixed Asset Manager.
+     * @Definition QBW only: the asset's cost or basis less
+                                accumulated depreciation as of the end of the year. Maintained
+                                by the QB Fixed Asset Manager.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -250,7 +287,8 @@ class IPPFixedAsset extends IPPIntuitEntity
      */
     public $BookValue;
     /**
-     * @Definition Internal use only: extension place holder for FixedAsset
+     * @Definition Internal use only: extension place holder for
+                                FixedAsset
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPGenericContactType.php
+++ b/src/Data/IPPGenericContactType.php
@@ -23,20 +23,20 @@ class IPPGenericContactType
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPGenericContactType', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPGenericContactType', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPGenericContactType', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPGenericContactType', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPGlobalTaxCalculationEnum.php
+++ b/src/Data/IPPGlobalTaxCalculationEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPGlobalTaxCalculationEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of tax model types.
+                Description: Enumeration of tax model
+                types.
 
  */
 class IPPGlobalTaxCalculationEnum
@@ -23,22 +24,22 @@ class IPPGlobalTaxCalculationEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPGlobalTaxCalculationEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPGlobalTaxCalculationEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPGlobalTaxCalculationEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPGlobalTaxCalculationEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPGlobalTaxCalculationEnum

--- a/src/Data/IPPGroupLineDetail.php
+++ b/src/Data/IPPGroupLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPGroupLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: Detail for a group item line, including the lines expanded from the group item.
+                Description: Detail for a group item
+                line, including the lines expanded from the group item.
 
  */
 class IPPGroupLineDetail
@@ -23,24 +24,25 @@ class IPPGroupLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPGroupLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPGroupLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPGroupLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPGroupLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to a group item for all the lines that belong to the group.
+                        Description: Reference to a group
+                        item for all the lines that belong to the group.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -51,7 +53,8 @@ class IPPGroupLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Quantity of the group item.
+                        Description: Quantity of the group
+                        item.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -63,7 +66,8 @@ class IPPGroupLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Unit of Measure reference.
+                        Description: Unit of Measure
+                        reference.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -75,7 +79,8 @@ class IPPGroupLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Date when the service is performed.
+                        Description: Date when the service is
+                        performed.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -87,7 +92,9 @@ class IPPGroupLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: The list of lines expanded from the group item. Note that a group line cannot itself contain group lines.
+                        Description: The list of lines
+                        expanded from the group item. Note that a group line cannot itself
+                        contain group lines.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -100,7 +107,8 @@ class IPPGroupLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Internal use only: extension place holder for GroupLineDetail
+                        Description: Internal use only:
+                        extension place holder for GroupLineDetail
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPHeader.php
+++ b/src/Data/IPPHeader.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPHeader
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPHeader', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPHeader', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPHeader', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPHeader', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @xmlType element
@@ -42,4 +42,6 @@ class IPPHeader
      * @var com\intuit\schema\finance\v3\IPPColData
      */
     public $ColData;
-} // end class IPPHeader
+}//end class
+
+ // end class IPPHeader

--- a/src/Data/IPPIdType.php
+++ b/src/Data/IPPIdType.php
@@ -23,22 +23,22 @@ class IPPIdType
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPIdType', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPIdType', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPIdType', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPIdType', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPIdType

--- a/src/Data/IPPIntuitAnyType.php
+++ b/src/Data/IPPIntuitAnyType.php
@@ -23,16 +23,16 @@ class IPPIntuitAnyType
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPIntuitAnyType', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPIntuitAnyType', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPIntuitAnyType', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPIntuitAnyType', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 } // end class IPPIntuitAnyType

--- a/src/Data/IPPIntuitBatchRequest.php
+++ b/src/Data/IPPIntuitBatchRequest.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPIntuitBatchRequest
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPIntuitBatchRequest', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPIntuitBatchRequest', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPIntuitBatchRequest', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPIntuitBatchRequest', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @xmlType element
@@ -43,4 +43,6 @@ class IPPIntuitBatchRequest
      * @var com\intuit\schema\finance\v3\IPPBatchItemRequest
      */
     public $BatchItemRequest;
-} // end class IPPIntuitBatchRequest
+}//end class
+
+ // end class IPPIntuitBatchRequest

--- a/src/Data/IPPIntuitEntity.php
+++ b/src/Data/IPPIntuitEntity.php
@@ -23,20 +23,20 @@ class IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPIntuitEntity', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPIntuitEntity', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPIntuitEntity', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPIntuitEntity', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPIntuitObject.php
+++ b/src/Data/IPPIntuitObject.php
@@ -11,24 +11,24 @@ class IPPIntuitObject extends IPPIntuitEntity
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPIntuitObject', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPIntuitObject', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPIntuitObject', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPIntuitObject', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 } // end class IPPIntuitObject

--- a/src/Data/IPPIntuitResponse.php
+++ b/src/Data/IPPIntuitResponse.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPIntuitResponse
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPIntuitResponse', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPIntuitResponse', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPIntuitResponse', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPIntuitResponse', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition Indication that a request was processed, but with possible exceptional circumstances (i.e. ignored unsupported fields) that the client may want to be aware of
@@ -43,6 +43,7 @@ class IPPIntuitResponse
      * @var com\intuit\schema\finance\v3\IPPWarnings
      */
     public $Warnings;
+
     /**
      * @Definition Any IntuitEntity derived entity like Customer, Invoice can be part of response
      * @xmlType element
@@ -50,6 +51,7 @@ class IPPIntuitResponse
      * @var IntuitObject
      */
     public $IntuitObject;
+
     /**
      * @Definition  Fault or Object should be returned
      * @xmlType element
@@ -60,6 +62,7 @@ class IPPIntuitResponse
      * @var com\intuit\schema\finance\v3\IPPFault
      */
     public $Fault;
+
     /**
      * @Definition Returns Report entity in case of report request
      * @xmlType element
@@ -70,6 +73,7 @@ class IPPIntuitResponse
      * @var com\intuit\schema\finance\v3\IPPReport
      */
     public $Report;
+
     /**
      * @Definition Returns QueryResponse entity in case of query
      * @xmlType element
@@ -80,6 +84,7 @@ class IPPIntuitResponse
      * @var com\intuit\schema\finance\v3\IPPQueryResponse
      */
     public $QueryResponse;
+
     /**
      * @Definition Returns BatchItems in response in case of Batch request
      * @xmlType element
@@ -90,6 +95,7 @@ class IPPIntuitResponse
      * @var com\intuit\schema\finance\v3\IPPBatchItemResponse
      */
     public $BatchItemResponse;
+
     /**
      * @Definition Returns CDCResponse
      * @xmlType element
@@ -100,6 +106,7 @@ class IPPIntuitResponse
      * @var com\intuit\schema\finance\v3\IPPCDCResponse
      */
     public $CDCResponse;
+
     /**
      * @Definition Returns AttachableResponse entity with response to file upload requests
      * @xmlType element
@@ -110,6 +117,7 @@ class IPPIntuitResponse
      * @var com\intuit\schema\finance\v3\IPPAttachableResponse
      */
     public $AttachableResponse;
+
     /**
      * @Definition Any IntuitResponseType type derived from IntuitResponseType
      * @xmlType element
@@ -120,6 +128,7 @@ class IPPIntuitResponse
      * @var com\intuit\schema\finance\v3\IPPSyncErrorResponse
      */
     public $SyncErrorResponse;
+
     /**
      * @Definition OLBTransaction object in the response
      * @xmlType element
@@ -130,6 +139,7 @@ class IPPIntuitResponse
      * @var com\intuit\schema\finance\v3\IPPOLBTransaction
      */
     public $OLBTransaction;
+
     /**
      * @Definition OLBStatus object in the response
      * @xmlType element
@@ -140,6 +150,7 @@ class IPPIntuitResponse
      * @var com\intuit\schema\finance\v3\IPPOLBStatus
      */
     public $OLBStatus;
+
     /**
      * @Definition Specifies the RequestId associated with the request
      * @xmlType attribute
@@ -147,6 +158,7 @@ class IPPIntuitResponse
      * @var string
      */
     public $requestId;
+
     /**
      * @Definition Specifies the time at which request started processing in the server
      * @xmlType attribute
@@ -154,6 +166,7 @@ class IPPIntuitResponse
      * @var string
      */
     public $time;
+
     /**
      * @Definition Specifies the HTTP codes result of the operation
      * @xmlType attribute
@@ -161,4 +174,6 @@ class IPPIntuitResponse
      * @var string
      */
     public $status;
-} // end class IPPIntuitResponse
+}//end class
+
+ // end class IPPIntuitResponse

--- a/src/Data/IPPInventorySite.php
+++ b/src/Data/IPPInventorySite.php
@@ -8,8 +8,10 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPInventorySite
  * @xmlDefinition
                 Product: QBW
-                Description: The InventorySite resource represents a location where inventory is stored.
-                Endpoint: inventorysite
+                Description: The InventorySite resource
+                represents a location where inventory is stored.
+                Endpoint:
+                inventorysite
                 Business Rules: [li]The site name must be unique.[/li]
 
  */
@@ -25,25 +27,26 @@ class IPPInventorySite extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPInventorySite', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPInventorySite', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPInventorySite', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPInventorySite', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBW
                                 Filterable: QBW
-                                Description: User recognizable name for the site
+                                Description: User
+                                recognizable name for the site
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -56,7 +59,8 @@ class IPPInventorySite extends IPPIntuitEntity
      * @Definition
                                 Product: QBW
                                 Filterable: QBW
-                                Description: Whether the site is considered "active", still in use by the business
+                                Description: Whether
+                                the site is considered "active", still in use by the business
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -68,7 +72,8 @@ class IPPInventorySite extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: Whether this is the default site for inventory items that do not indicate a site
+                                Description: Whether this is the
+                                default site for inventory items that do not indicate a site
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -92,7 +97,8 @@ class IPPInventorySite extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: Name of the person responsible for the site
+                                Description: Name of the person
+                                responsible for the site
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -128,7 +134,8 @@ class IPPInventorySite extends IPPIntuitEntity
      */
     public $ContactInfo;
     /**
-     * @Definition Internal use only: extension place holder for InventorySite
+     * @Definition Internal use only: extension place holder for
+                                InventorySite
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPInvoice.php
+++ b/src/Data/IPPInvoice.php
@@ -8,11 +8,39 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPInvoice
  * @xmlDefinition
                 Product: QBO
-                Description: The Invoice entity represents an invoice to a customer. Invoice could be based on salesterm with invoice and due dates for payment. Invoice supports sales tax, and shipping charges as a special line item. Invoice can be printed and emailed to a customer.
-                Business Rules: [li] An invoice must have at least one line that describes the item and an amount.[/li][li] An invoice must have a reference to a customer in the header.[/li]
+                Description: The Invoice entity
+                represents an invoice to a customer. Invoice could be based on
+                salesterm with invoice and due dates for payment. Invoice supports
+                sales tax, and shipping charges as a special line item. Invoice can
+                be printed and emailed to a customer.
+                Business Rules: [li] An invoice
+                must have at least one line that describes the item and an
+                amount.[/li][li] An invoice must have a reference to a customer in
+                the header.[/li]
                 Product: QBW
-                Description: An Invoice is a financial transaction representing a request for payment for goods or services that have been sold. An invoice is a form that records the details of a customer's purchase, such as quantity and price of the goods or services. An invoice records the amount owed by a customer who does not pay in full at the time of purchase. If full payment is received at the time of purchase, the sale may be recorded as a sales receipt, not an invoice.  An invoice must contain a valid customer reference in the CustomerId field and at least one line item. The referenced customer must already exist in the QuickBooks company at the desktop and any line items must also already exists in the QuickBooks company, or the attempt to sync will fail.[br /]In general, it is a good practice to specify all the header fields if you have the data.  You should always specify the ARAccountId; otherwise a default AR account will be used and this may give you unexpected results.[/br] If you want to apply one tax to all the transaction line items, use the TaxId or TaxGroupId field. If you want to use more than one tax, you need to use Tax Line items instead.
-                Business Rules: [li] An invoice must have at least one line that describes the item. [/li][li] If an account is specified in the header, the account must be of the Accounts Receivable (AR) type. [/li][li] An invoice must have a reference to a customer in the header.[/li]
+                Description: An Invoice is a financial transaction representing
+                a request for payment for goods or services that have been sold. An
+                invoice is a form that records the details of a customer's purchase,
+                such as quantity and price of the goods or services. An invoice
+                records the amount owed by a customer who does not pay in full at
+                the time of purchase. If full payment is received at the time of
+                purchase, the sale may be recorded as a sales receipt, not an
+                invoice. An invoice must contain a valid customer reference in the
+                CustomerId field and at least one line item. The referenced customer
+                must already exist in the QuickBooks company at the desktop and any
+                line items must also already exists in the QuickBooks company, or
+                the attempt to sync will fail.[br /]In general, it is a good
+                practice to specify all the header fields if you have the data. You
+                should always specify the ARAccountId; otherwise a default AR
+                account will be used and this may give you unexpected results.[/br]
+                If you want to apply one tax to all the transaction line items, use
+                the TaxId or TaxGroupId field. If you want to use more than one tax,
+                you need to use Tax Line items instead.
+                Business Rules: [li] An
+                invoice must have at least one line that describes the item.
+                [/li][li] If an account is specified in the header, the account must
+                be of the Accounts Receivable (AR) type. [/li][li] An invoice must
+                have a reference to a customer in the header.[/li]
 
  */
 class IPPInvoice extends IPPSalesTransaction
@@ -27,24 +55,25 @@ class IPPInvoice extends IPPSalesTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPInvoice', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPInvoice', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPInvoice', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPInvoice', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBO
-                                Description: Amount in deposit against the Invoice. Supported for Invoice only.
+                                Description: Amount in deposit
+                                against the Invoice. Supported for Invoice only.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -57,7 +86,8 @@ class IPPInvoice extends IPPSalesTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Specifies whether customer is allowed to use IPN to pay the Invoice
+                                Description: Specifies whether
+                                customer is allowed to use IPN to pay the Invoice
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -69,7 +99,9 @@ class IPPInvoice extends IPPSalesTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Specifies whether customer is allowed to use eInvoicing(online payment) to pay the Invoice
+                                Description: Specifies whether
+                                customer is allowed to use eInvoicing(online payment) to pay the
+                                Invoice
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -81,7 +113,9 @@ class IPPInvoice extends IPPSalesTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Specifies whether customer is allowed to use eInvoicing(online payment -credit card) to pay the Invoice
+                                Description: Specifies whether
+                                customer is allowed to use eInvoicing(online payment -credit
+                                card) to pay the Invoice
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -93,7 +127,9 @@ class IPPInvoice extends IPPSalesTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Specifies whether customer is allowed to use eInvoicing(online payment -bank or ach) to pay the Invoice
+                                Description: Specifies whether
+                                customer is allowed to use eInvoicing(online payment -bank or
+                                ach) to pay the Invoice
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -105,7 +141,8 @@ class IPPInvoice extends IPPSalesTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Specifies the eInvoice Status(SENT, VIEWED, PAID) for the invoice
+                                Description: Specifies the eInvoice
+                                Status(SENT, VIEWED, PAID) for the invoice
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -117,7 +154,8 @@ class IPPInvoice extends IPPSalesTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Specifies the eCloudStatus timeStamp(last Viewed/Sent/paid) for the invoice
+                                Description: Specifies the
+                                eCloudStatus timeStamp(last Viewed/Sent/paid) for the invoice
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -128,8 +166,50 @@ class IPPInvoice extends IPPSalesTransaction
     public $ECloudStatusTimeStamp;
     /**
      * @Definition
+                                Product: QBO
+                                Description: provides invoice statuses :
+                                MULTIPLE_ERRORS, DEPOSIT_ON_HOLD, DISPUTED, DEPOSIT_FAILED, PAYMENT_FAILED,
+                                OVERDUE_VIEWED, OVERDUE_NOT_SENT, OVERDUE_SENT,
+                                DUE_VIEWED, DUE_NOT_SENT, DUE_SENT,
+                                PAID_NOT_DEPOSITED, PARTIALLY_PAID, DEPOSITED, VOIDED, REVERSED
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName invoiceStatus
+     * @var string
+     */
+    public $invoiceStatus;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: call to action for this status
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName callToAction
+     * @var string
+     */
+    public $callToAction;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: invoice status log
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlMaxOccurs unbounded
+     * @xmlName invoiceStatusLog
+     * @var com\intuit\schema\finance\v3\IPPStatusInfo
+     */
+    public $invoiceStatusLog;
+    /**
+     * @Definition
                                 Product: ALL
-                                Description: Extension entity for Invoice.
+                                Description: Extension entity for
+                                Invoice.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPItem.php
+++ b/src/Data/IPPItem.php
@@ -8,10 +8,60 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPItem
  * @xmlDefinition
                 Product: QBO
-                Description: The Item resource represents any product or service that is sold or purchased. Inventory items are not currently supported.
+                Description: The Item resource
+                represents any product or service that is sold or purchased.
+                Inventory items are not currently supported.
                 Product: QBW
-                Description: An item is a thing that your company buys, sells, or re-sells, such as products, shipping and handling charges, discounts, and sales tax (if applicable). An item is shown as a line on an invoice or other sales form.  The Item.Type property, which specifies how the item is used, may have one of the following values: [li]Assembly: The Assembly item allows you combine inventory part items and other assembly items (subassemblies) into a single item by defining a Bill of Materials, that lists the component parts of the assembly item. You can also include the cost of building the assembly item by adding the non-inventory part items, service items, and other charge items to the Bill of Materials. [/li][li] Fixed Asset: The Fixed Asset item represents those business assets that you do not convert to cash one year of normal operation. A fixed asset is usually something that is integral to your business operations. For example, a truck or computer. [/li][li]Group: The Group item helps you to quickly enter a group of individual items that you often purchase or sell together. [li]Inventory: The Inventory item is used to track merchandise which your business purchases, stocks as inventory, and re-sells. QuickBooks tracks the current number of inventory items in stock and the average value of the inventory after the purchase and sale of every item. [/li][li]Other Charge: The Other Charge item is used to charge customers for the mileage expense.[/li] [li]Product The Product item is used to record the sales information of a product. [/li][li]Payment: The Payment item subtracts the amount of a customer payment from the total amount of an invoice or statement. You must create a payment item if you receive payment for an invoice or statement in parts. If you receive full payment at the time of sale, use a sales receipt form instead of an invoice with a payment item.[/li] [li]Service: The Service item is used for the services that you charge on the purchase. For example, including specialized labor, consulting hours, and professional fees. [/li][li]Subtotal: The Subtotal item is used when you want the total of all the items. You can use this item to apply a percentage discount or surcharge.[/li]
-                Business Rules: [li]The item name must be unique. [/li][li]The item type must not be NULL. [/li][li]The item cannot define both unit price and unit price percent simultaneously. [/li][li]For the Service, Product, and Other Charge items, you must specify the ID or name of the expense account or both. [/li][li]If the purchase order cost is specified for the Service, Product, and Other Charge items, you must specify the ID or name of the expense account or both.[/li] For the Inventory and Assembly items, you must specify: [li]the ID or name of the income account or both [/li][li]the ID or name of the cogs account or both [/li][li]the ID or name of the asset account or both [/li][li]For the Group item, you must specify the tax ID or tax name or both.[/li] For the Fixed Asset item, you must: [li]set the asset account type to Asset[/li] [li]specify the purchase date [/li][li]specify the ID or name of the income account or both[/li]
+                Description: An item is a thing that your company buys, sells,
+                or re-sells, such as products, shipping and handling charges,
+                discounts, and sales tax (if applicable). An item is shown as a line
+                on an invoice or other sales form. The Item.Type property, which
+                specifies how the item is used, may have one of the following
+                values: [li]Assembly: The Assembly item allows you combine inventory
+                part items and other assembly items (subassemblies) into a single
+                item by defining a Bill of Materials, that lists the component parts
+                of the assembly item. You can also include the cost of building the
+                assembly item by adding the non-inventory part items, service items,
+                and other charge items to the Bill of Materials. [/li][li] Fixed
+                Asset: The Fixed Asset item represents those business assets that
+                you do not convert to cash one year of normal operation. A fixed
+                asset is usually something that is integral to your business
+                operations. For example, a truck or computer. [/li][li]Group: The
+                Group item helps you to quickly enter a group of individual items
+                that you often purchase or sell together. [li]Inventory: The
+                Inventory item is used to track merchandise which your business
+                purchases, stocks as inventory, and re-sells. QuickBooks tracks the
+                current number of inventory items in stock and the average value of
+                the inventory after the purchase and sale of every item.
+                [/li][li]Other Charge: The Other Charge item is used to charge
+                customers for the mileage expense.[/li] [li]Product The Product item
+                is used to record the sales information of a product.
+                [/li][li]Payment: The Payment item subtracts the amount of a
+                customer payment from the total amount of an invoice or statement.
+                You must create a payment item if you receive payment for an invoice
+                or statement in parts. If you receive full payment at the time of
+                sale, use a sales receipt form instead of an invoice with a payment
+                item.[/li] [li]Service: The Service item is used for the services
+                that you charge on the purchase. For example, including specialized
+                labor, consulting hours, and professional fees. [/li][li]Subtotal:
+                The Subtotal item is used when you want the total of all the items.
+                You can use this item to apply a percentage discount or
+                surcharge.[/li]
+                Business Rules: [li]The item name must be unique.
+                [/li][li]The item type must not be NULL. [/li][li]The item cannot
+                define both unit price and unit price percent simultaneously.
+                [/li][li]For the Service, Product, and Other Charge items, you must
+                specify the ID or name of the expense account or both. [/li][li]If
+                the purchase order cost is specified for the Service, Product, and
+                Other Charge items, you must specify the ID or name of the expense
+                account or both.[/li] For the Inventory and Assembly items, you must
+                specify: [li]the ID or name of the income account or both
+                [/li][li]the ID or name of the cogs account or both [/li][li]the ID
+                or name of the asset account or both [/li][li]For the Group item,
+                you must specify the tax ID or tax name or both.[/li] For the Fixed
+                Asset item, you must: [li]set the asset account type to Asset[/li]
+                [li]specify the purchase date [/li][li]specify the ID or name of the
+                income account or both[/li]
 
  */
 class IPPItem extends IPPIntuitEntity
@@ -26,26 +76,28 @@ class IPPItem extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPItem', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPItem', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPItem', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPItem', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBW
-                                Description: User recognizable name for the Item.[br /]Max. length: 31 characters.
+                                Description: User recognizable name
+                                for the Item.[br /]Max. length: 31 characters.
                                 Product: QBO
-                                Description: User recognizable name for the Item.[br /]Max. length: 100 characters.
+                                Description: User recognizable name for the Item.[br /]Max.
+                                length: 100 characters.
                                 Filterable: ALL
                                 Sortable: ALL
                                 Required: QBW
@@ -60,7 +112,9 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Stock Keeping Unit - User entered item identifier that identifies an item uniquely [br /]Max. length: 100 characters.
+                                Description: Stock Keeping Unit -
+                                User entered item identifier that identifies an item uniquely
+                                [br /]Max. length: 100 characters.
                                 Filterable: ALL
                                 Sortable: ALL
 
@@ -74,9 +128,14 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: User entered description for the item that describes the details of the service or product.[br /]Max. length: 4000 characters.
-                                Product: QBO
-                                Description: User entered description for the item that describes the details of the service or product.[br /]Max. length: 4000 characters.
+                                Description: User entered
+                                description for the item that describes the details of the
+                                service or product.[br /]Max. length: 4000 characters.
+                                Product:
+                                QBO
+                                Description: User entered description for the item that
+                                describes the details of the service or product.[br /]Max.
+                                length: 4000 characters.
                                 Filterable: QBO
                                 Sortable: QBO
 
@@ -90,7 +149,9 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: True if active. Inactive items may be hidden from display and may not be used in financial transactions.
+                                Description: True if active.
+                                Inactive items may be hidden from display and may not be used in
+                                financial transactions.
                                 Filterable: QBW
 
      * @xmlType element
@@ -103,7 +164,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: True if the item is a subitem; false or null indicates a top-level item.
+                                Description: True if the item is a
+                                subitem; false or null indicates a top-level item.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -115,7 +177,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the item's parent entity.
+                                Description: Reference to the
+                                item's parent entity.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -127,7 +190,9 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Specifies the level of the item, 0 if top level parent, otherwise specifies the depth from the top parent.
+                                Description: Specifies the level of
+                                the item, 0 if top level parent, otherwise specifies the depth
+                                from the top parent.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -139,7 +204,12 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Fully qualified name of the entity. The fully qualified name prepends the topmost parent, followed by each sub element separated by colons. Takes the form of: [br /] Parent:Customer:Job:Sub-job [br /] Limited to 5 levels. Max. length: 41 characters (single name) or 209 characters (fully qualified name).
+                                Description: Fully qualified name
+                                of the entity. The fully qualified name prepends the topmost
+                                parent, followed by each sub element separated by colons. Takes
+                                the form of: [br /] Parent:Customer:Job:Sub-job [br /] Limited
+                                to 5 levels. Max. length: 41 characters (single name) or 209
+                                characters (fully qualified name).
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -151,7 +221,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: True if the item is subject to tax.
+                                Description: True if the item is
+                                subject to tax.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -163,7 +234,9 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: True if the sales tax is included in the item amount, and therefore is not calculated for the transaction.
+                                Description: True if the sales tax
+                                is included in the item amount, and therefore is not calculated
+                                for the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -175,7 +248,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: True if the tax amount is percentage based.
+                                Description: True if the tax amount
+                                is percentage based.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -188,7 +262,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Monetary value of the service or product, as expressed in the home currency.
+                                Description: Monetary value of the
+                                service or product, as expressed in the home currency.
                                 Filterable: QBW
                                 Sortable: QBW
 
@@ -202,7 +277,13 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: The tax amount expressed as a percent of charges entered in the current transaction. To enter a rate of 10% use 10.0, not 0.01.[br /]Applicable to the Service, OtherCharge or Part (Non-Inventory) item types only, and only if the Purchase part of the item does not exist, that is, the item is not used as a reimbursable item, or as a part in assemblies.
+                                Description: The tax amount
+                                expressed as a percent of charges entered in the current
+                                transaction. To enter a rate of 10% use 10.0, not 0.01.[br
+                                /]Applicable to the Service, OtherCharge or Part (Non-Inventory)
+                                item types only, and only if the Purchase part of the item does
+                                not exist, that is, the item is not used as a reimbursable item,
+                                or as a part in assemblies.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -214,7 +295,9 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Classification that specifies the use of this item.  See the description at the top of the Item entity page for details. [br /]
+                                Description: Classification that
+                                specifies the use of this item. See the description at the top
+                                of the Item entity page for details. [br /]
                                 Filterable: ALL
 
      * @xmlType element
@@ -227,7 +310,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to a PaymentMethod for an item of type Payment.
+                                Description: Reference to a
+                                PaymentMethod for an item of type Payment.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -239,7 +323,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the unit of measure set (UOM) entity used by this item.
+                                Description: Reference to the unit
+                                of measure set (UOM) entity used by this item.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -251,7 +336,10 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the posting account, that is, the account that records the proceeds from the sale of this item.[br /]Required for the the following types: Assembly, Inventory, Other Charge, Product, Service.
+                                Description: Reference to the
+                                posting account, that is, the account that records the proceeds
+                                from the sale of this item.[br /]Required for the the following
+                                types: Assembly, Inventory, Other Charge, Product, Service.
                                 Required: ALL
 
      * @xmlType element
@@ -264,7 +352,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: User entered purchase description for the item.
+                                Description: User entered purchase
+                                description for the item.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -276,7 +365,9 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: True if the purchase tax is included in the item amount, and therefore is not calculated for the transaction.
+                                Description: True if the purchase
+                                tax is included in the item amount, and therefore is not
+                                calculated for the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -288,7 +379,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Amount paid when buying or ordering the item, as expressed in the home currency.
+                                Description: Amount paid when
+                                buying or ordering the item, as expressed in the home currency.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -300,7 +392,14 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the expense account used to pay the vendor for this item.[br /]Note: for a service item, this may also be an equity account to record a draw against the company equity to pay for the service.[br /]If the Purchase information (PurchaseDesc, PurchaseTaxIncluded, PurchaseCost, etc.) is provided, this account is required for the the following item types: Other Charge, Product, Service.
+                                Description: Reference to the
+                                expense account used to pay the vendor for this item.[br /]Note:
+                                for a service item, this may also be an equity account to record
+                                a draw against the company equity to pay for the service.[br
+                                /]If the Purchase information (PurchaseDesc,
+                                PurchaseTaxIncluded, PurchaseCost, etc.) is provided, this
+                                account is required for the the following item types: Other
+                                Charge, Product, Service.
                                 Required: ALL
 
      * @xmlType element
@@ -313,7 +412,9 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the Cost of Goods Sold account for the inventory item.[br /]Required for the the following item types: Assembly, Inventory.
+                                Description: Reference to the Cost
+                                of Goods Sold account for the inventory item.[br /]Required for
+                                the the following item types: Assembly, Inventory.
                                 Required: ALL
 
      * @xmlType element
@@ -326,7 +427,12 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the Inventory Asset account that tracks the current value of the inventory. If the same account is used for all inventory items, the current balance of this account will represent the current total value of the inventory.[br /]Required for the the following item types: Assembly, Inventory.
+                                Description: Reference to the
+                                Inventory Asset account that tracks the current value of the
+                                inventory. If the same account is used for all inventory items,
+                                the current balance of this account will represent the current
+                                total value of the inventory.[br /]Required for the the
+                                following item types: Assembly, Inventory.
                                 Required: ALL
 
      * @xmlType element
@@ -339,7 +445,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the preferred vendor of this item.
+                                Description: Reference to the
+                                preferred vendor of this item.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -351,7 +458,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Average cost of the item, expressed in the home currency.
+                                Description: Average cost of the
+                                item, expressed in the home currency.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -363,7 +471,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Quantity on hand to be tracked.
+                                Description: Quantity on hand to be
+                                tracked.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -375,7 +484,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Current quantity of the inventory items available for sale.
+                                Description: Current quantity of
+                                the inventory items available for sale.
                                 Sortable: QBW
 
      * @xmlType element
@@ -388,7 +498,9 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Quantity of the inventory item being ordered, for which there is a purchase order issued.
+                                Description: Quantity of the
+                                inventory item being ordered, for which there is a purchase
+                                order issued.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -400,7 +512,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Quantity of the inventory item that is placed on sales orders.
+                                Description: Quantity of the
+                                inventory item that is placed on sales orders.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -412,7 +525,11 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Quantity on hand threshold below which a purchase order against this inventory item should be issued. When the QtyOnHand is less than the ReorderPoint, the QuickBooks purchase order system will prompt the user to reorder.
+                                Description: Quantity on hand
+                                threshold below which a purchase order against this inventory
+                                item should be issued. When the QtyOnHand is less than the
+                                ReorderPoint, the QuickBooks purchase order system will prompt
+                                the user to reorder.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -424,7 +541,10 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Identifier provided by manufacturer for the Item, for example, the model number.[br /]Applicable for the the following item types: Inventory, Product.
+                                Description: Identifier provided by
+                                manufacturer for the Item, for example, the model number.[br
+                                /]Applicable for the the following item types: Inventory,
+                                Product.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -436,7 +556,10 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Optional reference to the account in which the payment money is deposited.[br /]If not specified, the Undeposited Funds account will be used. Applicable to the Payment item type only.
+                                Description: Optional reference to
+                                the account in which the payment money is deposited.[br /]If not
+                                specified, the Undeposited Funds account will be used.
+                                Applicable to the Payment item type only.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -447,8 +570,10 @@ class IPPItem extends IPPIntuitEntity
     public $DepositToAccountRef;
     /**
      * @Definition
-                                 Product: ALL
-                                 Description: Reference to the sales tax code for the item.[br /]Applicable to the Service, Other Charge, Part (Non-Inventory), Inventory and Assembly item types only.
+                                Product: ALL
+                                Description: Reference to the sales tax code for the item.[br /]Applicable
+                                to the Service, Other Charge, Part (Non-Inventory), Inventory
+                                and Assembly item types only.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -460,7 +585,9 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the purchase tax code for the item.[br /]Applicable to the Service, Other Charge, and Part (Non-Inventory) item types.
+                                Description: Reference to the
+                                purchase tax code for the item.[br /]Applicable to the Service,
+                                Other Charge, and Part (Non-Inventory) item types.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -472,7 +599,13 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Date of the opening balance for the inventory transaction. QuickBooks creates the Opening Balance inventory transaction as of the given date, and calculates the total value by multiplying the cost by the quantity on hand.[br /]Applies to the Quantity On Hand and Total Value.[br /]Applicable to the Inventory and Assembly item types only.
+                                Description: Date of the opening
+                                balance for the inventory transaction. QuickBooks creates the
+                                Opening Balance inventory transaction as of the given date, and
+                                calculates the total value by multiplying the cost by the
+                                quantity on hand.[br /]Applies to the Quantity On Hand and Total
+                                Value.[br /]Applicable to the Inventory and Assembly item types
+                                only.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -484,7 +617,11 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Assembly item QuantityOnHand threshold below which more assemblies should be built.[br /]Applicable to the Assembly Item type only.[br /]When he quantity of the assembly item gets below the BuildPoint number, QuickBooks will remind the user to build more.
+                                Description: Assembly item
+                                QuantityOnHand threshold below which more assemblies should be
+                                built.[br /]Applicable to the Assembly Item type only.[br /]When
+                                he quantity of the assembly item gets below the BuildPoint
+                                number, QuickBooks will remind the user to build more.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -496,7 +633,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: Lets us know if the user wants to display the subitems as a group.  Applicable to items of Group type only.
+                                Description: Lets us know if the user wants to display the subitems as a
+                                group. Applicable to items of Group type only.
                                 Filterable: QBW
 
      * @xmlType element
@@ -509,7 +647,11 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: True if this is a special item used by QuickBooks in certain accounting functions, including miscellaneous charges that do not fall into the categories of service, labor, materials, or parts. Examples include delivery charges, setup fees, and service charges.
+                                Description: True if this is a
+                                special item used by QuickBooks in certain accounting functions,
+                                including miscellaneous charges that do not fall into the
+                                categories of service, labor, materials, or parts. Examples
+                                include delivery charges, setup fees, and service charges.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -521,7 +663,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description Type of special item, if SpecialItem is true.[br /]
+                                Description Type of special item,
+                                if SpecialItem is true.[br /]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -533,7 +676,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Contains the detailed components of the group. Applicable to a group item only.
+                                Description: Contains the detailed
+                                components of the group. Applicable to a group item only.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -545,7 +689,9 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Contains the detailed inventory parts used when the assembly is built. Applicable to an inventory assembly item only.
+                                Description: Contains the detailed
+                                inventory parts used when the assembly is built. Applicable to
+                                an inventory assembly item only.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -557,7 +703,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: India sales tax abatement rate.
+                                Description: India sales tax
+                                abatement rate.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -569,7 +716,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: India sales tax reverse charge rate.
+                                Description: India sales tax
+                                reverse charge rate.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -581,7 +729,8 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: India sales tax service type, see ServiceTypeEnum for values.
+                                Description: India sales tax
+                                service type, see ServiceTypeEnum for values.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -593,7 +742,10 @@ class IPPItem extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Categorizes the given item as a product or a service. The applicable values are those exposed through the ItemCategoryTypeEnum. This is currently applicable only in FR region.
+                                Description: Categorizes the given item as a product or a service. The
+                                applicable values are those exposed through the
+                                ItemCategoryTypeEnum. This is currently applicable only in FR
+                                region.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -603,7 +755,8 @@ class IPPItem extends IPPIntuitEntity
      */
     public $ItemCategoryType;
     /**
-     * @Definition Internal use only: extension place holder for Item
+     * @Definition Internal use only: extension place holder for
+                                Item
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPItemAssemblyDetail.php
+++ b/src/Data/IPPItemAssemblyDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPItemAssemblyDetail
  * @xmlDefinition
                 Product: ALL
-                Description: Contains the details of an inventory assembly item.
+                Description: Contains the details of an
+                inventory assembly item.
 
  */
 class IPPItemAssemblyDetail
@@ -23,24 +24,24 @@ class IPPItemAssemblyDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPItemAssemblyDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPItemAssemblyDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPItemAssemblyDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPItemAssemblyDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
-                            Product: ALL
-                            Description: Contains the line details of an inventory assembly item.
+                        Product: ALL
+                        Description: Contains the line details of an inventory assembly item.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPItemBasedExpenseLineDetail.php
+++ b/src/Data/IPPItemBasedExpenseLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPItemBasedExpenseLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: Item based expense detail for a transaction line.
+                Description: Item based expense detail
+                for a transaction line.
 
  */
 class IPPItemBasedExpenseLineDetail extends IPPItemLineDetail
@@ -23,24 +24,25 @@ class IPPItemBasedExpenseLineDetail extends IPPItemLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPItemBasedExpenseLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPItemBasedExpenseLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPItemBasedExpenseLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPItemBasedExpenseLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the Customer associated with the expense.
+                                Description: Reference to the
+                                Customer associated with the expense.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +54,8 @@ class IPPItemBasedExpenseLineDetail extends IPPItemLineDetail
     /**
      * @Definition
                                 Product: ALL
-                                Description: The billable status of the expense.[br /]
+                                Description: The billable status of
+                                the expense.[br /]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +67,8 @@ class IPPItemBasedExpenseLineDetail extends IPPItemLineDetail
     /**
      * @Definition
                                 Product: QBO
-                                Description: Indicates the total amount of line item including tax.
+                                Description: Indicates the total
+                                amount of line item including tax.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +80,8 @@ class IPPItemBasedExpenseLineDetail extends IPPItemLineDetail
     /**
      * @Definition
                                 Product: ALL
-                                Description: Internal use only: extension place holder for ExpenseItemDetail
+                                Description: Internal use only:
+                                extension place holder for ExpenseItemDetail
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPItemCategoryTypeEnum.php
+++ b/src/Data/IPPItemCategoryTypeEnum.php
@@ -23,22 +23,22 @@ class IPPItemCategoryTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPItemCategoryTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPItemCategoryTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPItemCategoryTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPItemCategoryTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPItemCategoryTypeEnum

--- a/src/Data/IPPItemComponentLine.php
+++ b/src/Data/IPPItemComponentLine.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPItemComponentLine
  * @xmlDefinition
                 Product: ALL
-                Description: Constituent line of a group item.
+                Description: Constituent line of a
+                group item.
 
  */
 class IPPItemComponentLine
@@ -23,24 +24,25 @@ class IPPItemComponentLine
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPItemComponentLine', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPItemComponentLine', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPItemComponentLine', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPItemComponentLine', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
-                            Product: ALL
-                            Description: Reference to an Item. For an Assembly item, this must be a reference to an Inventory Item needed in the assembly.
+                        Product: ALL
+                        Description: Reference to an Item. For an Assembly item, this must be a
+                        reference to an Inventory Item needed in the assembly.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -51,8 +53,8 @@ class IPPItemComponentLine
     public $ItemRef;
     /**
      * @Definition
-                            Product: ALL
-                            Description: Quantity of items.
+                        Product: ALL
+                        Description: Quantity of items.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -63,8 +65,9 @@ class IPPItemComponentLine
     public $Qty;
     /**
      * @Definition
-                            Product: ALL
-                            Description: Reference to the unit of measure (within UOMSetRef) for this line item. Examples: "each" or "box".
+                        Product: ALL
+                        Description: Reference to the unit of measure (within UOMSetRef) for this line
+                        item. Examples: "each" or "box".
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPItemGroupDetail.php
+++ b/src/Data/IPPItemGroupDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPItemGroupDetail
  * @xmlDefinition
                 Product: ALL
-                Description: Contains the details of a group item.
+                Description: Contains the details of a
+                group item.
 
  */
 class IPPItemGroupDetail
@@ -23,24 +24,24 @@ class IPPItemGroupDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPItemGroupDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPItemGroupDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPItemGroupDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPItemGroupDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
-                            Product: ALL
-                            Description: Contains the line details of a group item.
+                        Product: ALL
+                        Description: Contains the line details of a group item.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPItemLineDetail.php
+++ b/src/Data/IPPItemLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPItemLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: Information about the goods sold: what is sold, how much/many and for what price.
+                Description: Information about the
+                goods sold: what is sold, how much/many and for what price.
 
  */
 class IPPItemLineDetail
@@ -23,24 +24,26 @@ class IPPItemLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPItemLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPItemLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPItemLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPItemLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the Item. When a line lacks an ItemRef it will be treated as "documentation" and the Amount will be ignored.
+                        Description: Reference to the Item.
+                        When a line lacks an ItemRef it will be treated as "documentation"
+                        and the Amount will be ignored.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +55,8 @@ class IPPItemLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the Class for the line item.
+                        Description: Reference to the Class
+                        for the line item.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +68,8 @@ class IPPItemLineDetail
     /**
      * @Definition
                             Product: ALL
-                            Description: Unit price of the service or item for the line.
+                            Description: Unit price of the
+                            service or item for the line.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +81,9 @@ class IPPItemLineDetail
     /**
      * @Definition
                             Product: ALL
-                            Description: The amount is expressed as a percent of charges already entered in the current transaction. To enter a rate of 10% use 10.0, not 0.01.
+                            Description: The amount is expressed
+                            as a percent of charges already entered in the current
+                            transaction. To enter a rate of 10% use 10.0, not 0.01.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -88,7 +95,8 @@ class IPPItemLineDetail
     /**
      * @Definition
                             Product: ALL
-                            Description: Reference to the PriceLevel of the service or item for the line.
+                            Description: Reference to the
+                            PriceLevel of the service or item for the line.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -100,7 +108,8 @@ class IPPItemLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Markup information for the Item wherever applicable.
+                        Description: Markup information for
+                        the Item wherever applicable.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -112,7 +121,8 @@ class IPPItemLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Number of items for the line.
+                        Description: Number of items for the
+                        line.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -124,7 +134,8 @@ class IPPItemLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the UOMSetREf (unit of mesasure set) that applies to this item.
+                        Description: Reference to the
+                        UOMSetREf (unit of mesasure set) that applies to this item.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -136,7 +147,9 @@ class IPPItemLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: An account different than the account associated with the Item in the current transaction line.  Cannot be updated or modified.
+                        Description: An account different
+                        than the account associated with the Item in the current
+                        transaction line. Cannot be updated or modified.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -148,7 +161,8 @@ class IPPItemLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the InventorySite where this item is located.
+                        Description: Reference to the
+                        InventorySite where this item is located.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -160,7 +174,8 @@ class IPPItemLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the SalesTaxCode for this item.
+                        Description: Reference to the
+                        SalesTaxCode for this item.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -169,4 +184,17 @@ class IPPItemLineDetail
      * @var com\intuit\schema\finance\v3\IPPReferenceType
      */
     public $TaxCodeRef;
+    /**
+     * @Definition
+                        Product: ALL
+                        Description: Reference to the
+                        SalesTaxCode for this item.
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName TaxClassificationRef
+     * @var com\intuit\schema\finance\v3\IPPReferenceType
+     */
+    public $TaxClassificationRef;
 } // end class IPPItemLineDetail

--- a/src/Data/IPPItemReceiptLineDetail.php
+++ b/src/Data/IPPItemReceiptLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPItemReceiptLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: ItemReceipt detail for a transaction line.
+                Description: ItemReceipt detail for a
+                transaction line.
 
  */
 class IPPItemReceiptLineDetail
@@ -23,24 +24,25 @@ class IPPItemReceiptLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPItemReceiptLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPItemReceiptLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPItemReceiptLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPItemReceiptLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: Internal use only: extension place holder for ItemReceiptDetail
+                        Description: Internal use only:
+                        extension place holder for ItemReceiptDetail
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPItemTypeEnum.php
+++ b/src/Data/IPPItemTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPItemTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of types of Items in QuickBooks.
+                Description: Enumeration of types of
+                Items in QuickBooks.
 
  */
 class IPPItemTypeEnum
@@ -23,22 +24,22 @@ class IPPItemTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPItemTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPItemTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPItemTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPItemTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPItemTypeEnum

--- a/src/Data/IPPJobInfo.php
+++ b/src/Data/IPPJobInfo.php
@@ -23,20 +23,20 @@ class IPPJobInfo
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPJobInfo', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPJobInfo', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPJobInfo', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPJobInfo', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPJobStatusEnum.php
+++ b/src/Data/IPPJobStatusEnum.php
@@ -23,22 +23,22 @@ class IPPJobStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPJobStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPJobStatusEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPJobStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPJobStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPJobStatusEnum

--- a/src/Data/IPPJobType.php
+++ b/src/Data/IPPJobType.php
@@ -23,20 +23,20 @@ class IPPJobType extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPJobType', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPJobType', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPJobType', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPJobType', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBW

--- a/src/Data/IPPJournalCode.php
+++ b/src/Data/IPPJournalCode.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType IntuitEntity
  * @xmlName IPPJournalCode
  * @var IPPJournalCode
- * @xmlDefinition Journal Code is a compliance requirement in FR. A journal code is assigned to each transaction and it depends on whether it is a income or a expense.
+ * @xmlDefinition Journal Code is a compliance requirement in FR. A
+                journal code is assigned to each transaction and it depends on
+                whether it is a income or a expense.
  */
 class IPPJournalCode extends IPPIntuitEntity
 {
@@ -20,22 +22,23 @@ class IPPJournalCode extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPJournalCode', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPJournalCode', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPJournalCode', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPJournalCode', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition The two letter name for the journal code
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -44,7 +47,9 @@ class IPPJournalCode extends IPPIntuitEntity
      */
     public $Name;
     /**
-     * @Definition  The type of the Journal Code. The applicable values are those exposed through the JournalCodeTypeEnum.
+     * @Definition  The type of the Journal Code. The applicable
+                                values are those exposed through the JournalCodeTypeEnum.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -54,6 +59,7 @@ class IPPJournalCode extends IPPIntuitEntity
     public $Type;
     /**
      * @Definition The description of the Journal Code
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -62,7 +68,8 @@ class IPPJournalCode extends IPPIntuitEntity
      */
     public $Description;
     /**
-     * @Definition Whether or not Journal codes may be hidden for display purposes
+     * @Definition Whether or not Journal codes may be hidden for
+                                display purposes
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -71,7 +78,8 @@ class IPPJournalCode extends IPPIntuitEntity
      */
     public $Active;
     /**
-     * @Definition Internal use only: extension place holder for Journal Code extensible element
+     * @Definition Internal use only: extension place holder for
+                                Journal Code extensible element
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPJournalCodeTypeEnum.php
+++ b/src/Data/IPPJournalCodeTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPJournalCodeTypeEnum
  * @xmlDefinition
                 Product: QBO
-                Description: Enumeration of the different types of Journal Codes applicable in FR
+                Description: Enumeration of the different types of Journal Codes applicable in
+                FR
 
  */
 class IPPJournalCodeTypeEnum
@@ -23,22 +24,22 @@ class IPPJournalCodeTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPJournalCodeTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPJournalCodeTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPJournalCodeTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPJournalCodeTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPJournalCodeTypeEnum

--- a/src/Data/IPPJournalEntry.php
+++ b/src/Data/IPPJournalEntry.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType Transaction
  * @xmlName IPPJournalEntry
  * @var IPPJournalEntry
- * @xmlDefinition Accounting transaction, consists of journal lines, each of which is either a debit or a credit. The total of the debits must equal the total of the credits.
+ * @xmlDefinition Accounting transaction, consists of journal lines,
+                each of which is either a debit or a credit. The total of the debits
+                must equal the total of the credits.
  */
 class IPPJournalEntry extends IPPTransaction
 {
@@ -20,22 +22,24 @@ class IPPJournalEntry extends IPPTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPJournalEntry', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPJournalEntry', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPJournalEntry', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPJournalEntry', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition Indicates that the Journal Entry is after-the-fact entry to make changes to specific accounts.
+     * @Definition Indicates that the Journal Entry is
+                                after-the-fact entry to make changes to specific accounts.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -44,10 +48,17 @@ class IPPJournalEntry extends IPPTransaction
      */
     public $Adjustment;
     /**
-     * @Definition Valid only if the company file is set up to use Multi-Currency feature.
+     * @Definition Valid only if the company file is set up to use
+                                Multi-Currency feature.
                                 [b]QuickBooks Notes[/b][br /]
-                                At the end of a reporting period, when financial reports need to reflect a current home currency value of the foreign balances, enter a home currency adjustment.
-                                Until the home currency value of the foreign balances is recalculated using current exchange rates, reports reflect the home currency value based on the exchange rates used at the time of each transaction.
+                                At the end
+                                of a reporting period, when financial reports need to reflect a
+                                current home currency value of the foreign balances, enter a
+                                home currency adjustment.
+                                Until the home currency value of the foreign balances is recalculated
+                                using current exchange rates, reports reflect the home currency
+                                value based on the exchange rates used at the time of each
+                                transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -57,9 +68,12 @@ class IPPJournalEntry extends IPPTransaction
      */
     public $HomeCurrencyAdjustment;
     /**
-     * @Definition Valid only if the company file is set up to use Multi-Currency feature.
+     * @Definition Valid only if the company file is set up to use
+                                Multi-Currency feature.
                                 [b]QuickBooks Notes[/b][br /]
-                                Amounts are always entered in home currency for a HomeCurrencyAdjustment JournalEntry.
+                                Amounts are
+                                always entered in home currency for a HomeCurrencyAdjustment
+                                JournalEntry.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -71,9 +85,15 @@ class IPPJournalEntry extends IPPTransaction
     /**
      * @Definition
                                 Product: All
-                                Description: Indicates the total amount of the transaction. This includes the total of all the charges, allowances and taxes. By default, this is recalculated based on sub items total and overridden.
+                                Description: Indicates the total
+                                amount of the transaction. This includes the total of all the
+                                charges, allowances and taxes. By default, this is recalculated
+                                based on sub items total and overridden.
                                 Product: QBW
-                                Description: Indicates the total amount of the transaction. This includes the total of all the charges, allowances and taxes.[br /]Calculated by QuickBooks business logic; cannot be written to QuickBooks.
+                                Description: Indicates the total amount of the transaction. This
+                                includes the total of all the charges, allowances and taxes.[br
+                                /]Calculated by QuickBooks business logic; cannot be written to
+                                QuickBooks.
                                 Filterable: QBW
                                 Sortable: QBW
 
@@ -87,7 +107,12 @@ class IPPJournalEntry extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: Total amount of the transaction in the home currency for multi-currency enabled companies. Single currency companies will not have this field. Includes the total of all the charges, allowances and taxes. Calculated by QuickBooks business logic. Cannot be written to QuickBooks.
+                                Description: Total amount of the
+                                transaction in the home currency for multi-currency enabled
+                                companies. Single currency companies will not have this field.
+                                Includes the total of all the charges, allowances and taxes.
+                                Calculated by QuickBooks business logic. Cannot be written to
+                                QuickBooks.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -97,7 +122,8 @@ class IPPJournalEntry extends IPPTransaction
      */
     public $HomeTotalAmt;
     /**
-     * @Definition Internal use only: extension place holder for JournalEntry
+     * @Definition Internal use only: extension place holder for
+                                JournalEntry
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPJournalEntryLineDetail.php
+++ b/src/Data/IPPJournalEntryLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPJournalEntryLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: JournalEntry detail for a transaction line.
+                Description: JournalEntry detail for a
+                transaction line.
 
  */
 class IPPJournalEntryLineDetail
@@ -23,24 +24,25 @@ class IPPJournalEntryLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPJournalEntryLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPJournalEntryLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPJournalEntryLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPJournalEntryLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: Indicates whether the JournalEntry line is a Debit or Credit.[br /]
+                        Description: Indicates whether the
+                        JournalEntry line is a Debit or Credit.[br /]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +54,9 @@ class IPPJournalEntryLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference information for the Entity (Customer/Vendor/Employee) associated with the JournalEntry line.
+                        Description: Reference information
+                        for the Entity (Customer/Vendor/Employee) associated with the
+                        JournalEntry line.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +68,8 @@ class IPPJournalEntryLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the Account associated with the JournalEntry line.
+                        Description: Reference to the Account
+                        associated with the JournalEntry line.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +81,8 @@ class IPPJournalEntryLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the Class associated with the JournalEntry line.
+                        Description: Reference to the Class
+                        associated with the JournalEntry line.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -88,7 +94,8 @@ class IPPJournalEntryLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: Represents Department Reference associated with the JournalEntry line.
+                        Description: Represents Department
+                        Reference associated with the JournalEntry line.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -100,7 +107,8 @@ class IPPJournalEntryLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: Sales/Purchase tax code associated with the JournalEntry Line. For Non US/CA Companies
+                        Description: Sales/Purchase tax code
+                        associated with the JournalEntry Line. For Non US/CA Companies
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -112,7 +120,8 @@ class IPPJournalEntryLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: Indicates whether the tax applicable on the line is sales or purchase
+                        Description: Indicates whether the
+                        tax applicable on the line is sales or purchase
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -124,7 +133,8 @@ class IPPJournalEntryLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: Tax applicable for this line transaction line
+                        Description: Tax applicable for this
+                        line transaction line
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -136,7 +146,10 @@ class IPPJournalEntryLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: The billable status of the journal entry line. The line is to be billed to a customer if the account is an expense account and the Entity Reference specifies a Customer or a Job.[br /]
+                        Description: The billable status of
+                        the journal entry line. The line is to be billed to a customer if
+                        the account is an expense account and the Entity Reference
+                        specifies a Customer or a Job.[br /]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -148,7 +161,8 @@ class IPPJournalEntryLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: The Journal Code that should be associated for every journal entry line. This is applicable only for FR.
+                        Description: The Journal Code that should be associated for every journal
+                        entry line. This is applicable only for FR.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -160,7 +174,8 @@ class IPPJournalEntryLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Internal use only: extension place holder for JournalEntryDetail
+                        Description: Internal use only:
+                        extension place holder for JournalEntryDetail
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPLine.php
+++ b/src/Data/IPPLine.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPLine
  * @xmlDefinition
                 Product: ALL
-                Description: A line item of a transaction.
+                Description: A line item of a
+                transaction.
 
  */
 class IPPLine
@@ -23,26 +24,34 @@ class IPPLine
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPLine', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPLine', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPLine', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPLine', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: QBW
                         Description: ID of the Line Item.
                         Product: QBO
-                        Description: ID of the Line Item.[br /]QBO considers a request as an update operation for a line item, if you provide an ID that is greater than zero and the ID exists in QBO.[br /]QBO considers a request as an create operation for a line item in any of the following conditions: No ID provided, ID provided is less than or equal to zero, ID provided is greater than zero and does not exist in QuickBooks.[br /]Required for updating existing lines.[br /]Not supported for BillPayment, Estimate, Invoice, or Payment.
+                        Description: ID of the Line Item.[br /]QBO considers a
+                        request as an update operation for a line item, if you provide an
+                        ID that is greater than zero and the ID exists in QBO.[br /]QBO
+                        considers a request as an create operation for a line item in any
+                        of the following conditions: No ID provided, ID provided is less
+                        than or equal to zero, ID provided is greater than zero and does
+                        not exist in QuickBooks.[br /]Required for updating existing
+                        lines.[br /]Not supported for BillPayment, Estimate, Invoice, or
+                        Payment.
                         Required: QBO
 
      * @xmlType element
@@ -55,7 +64,9 @@ class IPPLine
     /**
      * @Definition
                         Product: QBW
-                        Description: Specifies the position of the line in the collection of transaction lines. Supported only for QuickBooks Windows desktop.
+                        Description: Specifies the position
+                        of the line in the collection of transaction lines. Supported only
+                        for QuickBooks Windows desktop.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -67,9 +78,14 @@ class IPPLine
     /**
      * @Definition
                         Product: QBO
-                        Description: Free form text description of the line item that appears in the printed record.[br /]Max. length: 4000 characters.[br /]Not supported for BillPayment or Payment.
+                        Description: Free form text
+                        description of the line item that appears in the printed
+                        record.[br /]Max. length: 4000 characters.[br /]Not supported for
+                        BillPayment or Payment.
                         Product: QBW
-                        Description: Free form text description of the line item that appears in the printed record. Max. length: 4000 characters.
+                        Description: Free form text
+                        description of the line item that appears in the printed record.
+                        Max. length: 4000 characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -81,9 +97,16 @@ class IPPLine
     /**
      * @Definition
                         Product: QBW
-                        Description: The amount of the line, which depends on the type of the line. It can represent the discount amount, charge amount, tax amount, or subtotal amount based on the line type detail.
+                        Description: The amount of the line,
+                        which depends on the type of the line. It can represent the
+                        discount amount, charge amount, tax amount, or subtotal amount
+                        based on the line type detail.
                         Product: QBO
-                        Description: The amount of the line depending on the type of the line. It can represent the discount amount, charge amount, tax amount, or subtotal amount based on the line type detail.[br /]Required for BillPayment, Check, Estimate, Invoice, JournalEntry, Payment, SalesReceipt.
+                        Description: The amount
+                        of the line depending on the type of the line. It can represent
+                        the discount amount, charge amount, tax amount, or subtotal amount
+                        based on the line type detail.[br /]Required for BillPayment,
+                        Check, Estimate, Invoice, JournalEntry, Payment, SalesReceipt.
                         Required: QBO
 
      * @xmlType element
@@ -96,7 +119,9 @@ class IPPLine
     /**
      * @Definition
                         Product: ALL
-                        Description: A link between this line and a specific transaction.  For example, an invoice line may link to an estimate.
+                        Description: A link between this line
+                        and a specific transaction. For example, an invoice line may link
+                        to an estimate.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -109,7 +134,8 @@ class IPPLine
     /**
      * @Definition
                         Product: ALL
-                        Description: The type of line in the transaction.[br /]
+                        Description: The type of line in the
+                        transaction.[br /]
                         Required: ALL
 
      * @xmlType element
@@ -123,7 +149,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: PaymentDetail type for the transaction.
+                            Description: PaymentDetail type for
+                            the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -134,7 +161,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: DiscountDetail type for the transaction.
+                            Description: DiscountDetail type for
+                            the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -145,7 +173,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: SalesTaxDetail type for the transaction.
+                            Description: SalesTaxDetail type for
+                            the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -156,7 +185,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: SalesItem type for the transaction.
+                            Description: SalesItem type for the
+                            transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -167,7 +197,8 @@ class IPPLine
     /**
      * @Definition
                             Product: QBW
-                            Description: Custom field (or data extension). Supported only for QuickBooks Windows desktop.
+                            Description: Custom field (or data
+                            extension). Supported only for QuickBooks Windows desktop.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -178,7 +209,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: ExpenseItem type for the transaction.
+                            Description: ExpenseItem type for
+                            the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -189,7 +221,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: AccountExpense type for the transaction.
+                            Description: AccountExpense type for
+                            the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -200,7 +233,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: Deposit type for the transaction.
+                            Description: Deposit type for the
+                            transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -211,7 +245,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: PurchaseOrderItem type for the transaction.
+                            Description: PurchaseOrderItem type
+                            for the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -222,7 +257,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: SalesOrderItem type for the transaction.
+                            Description: SalesOrderItem type for
+                            the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -233,7 +269,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: ItemReceipt type for the transaction.
+                            Description: ItemReceipt type for
+                            the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -244,7 +281,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: JournalEntry type for the transaction.
+                            Description: JournalEntry type for
+                            the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -255,7 +293,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: GroupLine type for the transaction.
+                            Description: GroupLine type for the
+                            transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -266,7 +305,8 @@ class IPPLine
     /**
      * @Definition
                             Product: ALL
-                            Description: SubTotalLine type for the transaction.
+                            Description: SubTotalLine type for
+                            the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -277,7 +317,8 @@ class IPPLine
     /**
      * @Definition
                             Product: QBO
-                            Description: TDS line type for the transaction.
+                            Description: TDS line type for the
+                            transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -288,7 +329,8 @@ class IPPLine
     /**
      * @Definition
                         Product: QBW
-                        Description: Custom field (or data extension). Supported only for QuickBooks Windows desktop.
+                        Description: Custom field (or data
+                        extension). Supported only for QuickBooks Windows desktop.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -301,7 +343,8 @@ class IPPLine
     /**
      * @Definition
                         Product: ALL
-                        Description: Internal use only: extension place holder for LineBase
+                        Description: Internal use only:
+                        extension place holder for LineBase
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPLineDetailTypeEnum.php
+++ b/src/Data/IPPLineDetailTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPLineDetailTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration line detail types.
+                Description: Enumeration line detail
+                types.
 
  */
 class IPPLineDetailTypeEnum
@@ -23,22 +24,22 @@ class IPPLineDetailTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPLineDetailTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPLineDetailTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPLineDetailTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPLineDetailTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPLineDetailTypeEnum

--- a/src/Data/IPPLinkedTxn.php
+++ b/src/Data/IPPLinkedTxn.php
@@ -6,7 +6,11 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType
  * @xmlName IPPLinkedTxn
  * @var IPPLinkedTxn
- * @xmlDefinition That minimal subset of transaction information which is included on another  transaction, so that a client viewing the second transaction entity need not make an additional request to the service in order to render it in human readable form.  (e.g a payment needs to refer to an invoice by number)
+ * @xmlDefinition That minimal subset of transaction information
+                which is included on another transaction, so that a client viewing
+                the second transaction entity need not make an additional request to
+                the service in order to render it in human readable form. (e.g a
+                payment needs to refer to an invoice by number)
  */
 class IPPLinkedTxn
 {
@@ -20,26 +24,31 @@ class IPPLinkedTxn
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPLinkedTxn', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPLinkedTxn', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPLinkedTxn', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPLinkedTxn', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: QBW
-                        Description: Transaction the current entity is related to (linked to), for example, Sales Order.[br /]UNSUPPORTED FIELD.
+                        Description: Transaction the current
+                        entity is related to (linked to), for example, Sales Order.[br
+                        /]UNSUPPORTED FIELD.
                         Product: QBO
-                        Description: A list of Estimate Ids that are to be associated with the invoice.[br /]Note: Only Pending and Accepted Estimates can be specified. Closed and Rejected estimates will be ignored.
+                        Description: A list of Estimate
+                        Ids that are to be associated with the invoice.[br /]Note: Only
+                        Pending and Accepted Estimates can be specified. Closed and
+                        Rejected estimates will be ignored.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -63,7 +72,9 @@ class IPPLinkedTxn
     /**
      * @Definition
                         Product: ALL
-                        Description: A link to a specific line of the LinkedTxn.  If supplied the LinkedTxn field must also be populated.
+                        Description: A link to a specific
+                        line of the LinkedTxn. If supplied the LinkedTxn field must also
+                        be populated.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPMarkupInfo.php
+++ b/src/Data/IPPMarkupInfo.php
@@ -23,24 +23,25 @@ class IPPMarkupInfo
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPMarkupInfo', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPMarkupInfo', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPMarkupInfo', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPMarkupInfo', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: True if the markup is expressed as a percentage.
+                        Description: True if the markup is
+                        expressed as a percentage.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +65,9 @@ class IPPMarkupInfo
     /**
      * @Definition
                         Product: ALL
-                        Description: Markup amount expressed as a percent of charges already entered in the current transaction. To enter a rate of 10% use 10.0, not 0.01.
+                        Description: Markup amount expressed
+                        as a percent of charges already entered in the current
+                        transaction. To enter a rate of 10% use 10.0, not 0.01.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +79,8 @@ class IPPMarkupInfo
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to a PriceLevel for the markup.
+                        Description: Reference to a
+                        PriceLevel for the markup.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -85,4 +89,17 @@ class IPPMarkupInfo
      * @var com\intuit\schema\finance\v3\IPPReferenceType
      */
     public $PriceLevelRef;
+    /**
+     * @Definition
+                        Product: ALL
+                        Description: An account associated with markup info.
+                        Cannot be updated or modified.
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName MarkUpIncomeAccountRef
+     * @var com\intuit\schema\finance\v3\IPPReferenceType
+     */
+    public $MarkUpIncomeAccountRef;
 } // end class IPPMarkupInfo

--- a/src/Data/IPPMasterAccount.php
+++ b/src/Data/IPPMasterAccount.php
@@ -6,7 +6,11 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType Account
  * @xmlName IPPMasterAccount
  * @var IPPMasterAccount
- * @xmlDefinition Master Account is the list of accounts in the master list. The master list is the complete list of accounts prescribed by the French Government. These accounts can be created in the company on a need basis. The account create API needs to be used to create an account.
+ * @xmlDefinition Master Account is the list of accounts in the
+                master list. The master list is the complete list of accounts
+                prescribed by the French Government. These accounts can be created
+                in the company on a need basis. The account create API needs to be
+                used to create an account.
  */
 class IPPMasterAccount extends IPPAccount
 {
@@ -20,20 +24,20 @@ class IPPMasterAccount extends IPPAccount
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPMasterAccount', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPMasterAccount', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPMasterAccount', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPMasterAccount', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL

--- a/src/Data/IPPMemoRef.php
+++ b/src/Data/IPPMemoRef.php
@@ -8,7 +8,9 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPMemoRef
  * @xmlDefinition
                 Product: ALL
-                Description:  Captures a memo on a transaction that may (QBW) reference a company pre-defined message (See CustomerMsg)
+                Description: Captures a memo on a
+                transaction that may (QBW) reference a company pre-defined message
+                (See CustomerMsg)
 
  */
 class IPPMemoRef
@@ -23,27 +25,28 @@ class IPPMemoRef
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPMemoRef', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPMemoRef', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPMemoRef', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPMemoRef', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
     /**
      * @Definition
-                            Product: QBW: the ID of the CustomerMsg entity used to provide the string content
+                            Product: QBW: the ID of the CustomerMsg entity
+                            used to provide the string content
 
      * @xmlType attribute
      * @xmlName id

--- a/src/Data/IPPModificationMetaData.php
+++ b/src/Data/IPPModificationMetaData.php
@@ -23,20 +23,20 @@ class IPPModificationMetaData
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPModificationMetaData', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPModificationMetaData', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPModificationMetaData', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPModificationMetaData', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: QBW

--- a/src/Data/IPPMoney.php
+++ b/src/Data/IPPMoney.php
@@ -23,20 +23,20 @@ class IPPMoney
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPMoney', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPMoney', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPMoney', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPMoney', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPMonthEnum.php
+++ b/src/Data/IPPMonthEnum.php
@@ -20,22 +20,22 @@ class IPPMonthEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPMonthEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPMonthEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPMonthEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPMonthEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPMonthEnum

--- a/src/Data/IPPNameBase.php
+++ b/src/Data/IPPNameBase.php
@@ -23,20 +23,20 @@ class IPPNameBase extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPNameBase', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPNameBase', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPNameBase', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPNameBase', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBO

--- a/src/Data/IPPNameValue.php
+++ b/src/Data/IPPNameValue.php
@@ -23,20 +23,20 @@ class IPPNameValue
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPNameValue', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPNameValue', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPNameValue', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPNameValue', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPNumberTypeCustomFieldDefinition.php
+++ b/src/Data/IPPNumberTypeCustomFieldDefinition.php
@@ -23,20 +23,20 @@ class IPPNumberTypeCustomFieldDefinition extends IPPCustomFieldDefinition
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPNumberTypeCustomFieldDefinition', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPNumberTypeCustomFieldDefinition', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPNumberTypeCustomFieldDefinition', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPNumberTypeCustomFieldDefinition', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL

--- a/src/Data/IPPOLBAccount.php
+++ b/src/Data/IPPOLBAccount.php
@@ -20,20 +20,20 @@ class IPPOLBAccount
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPOLBAccount', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPOLBAccount', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPOLBAccount', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPOLBAccount', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
@@ -47,7 +47,8 @@ class IPPOLBAccount
      */
     public $AccountId;
     /**
-     * @Definition Account details that contains possibly credit card number, last 5 digits
+     * @Definition Account details that contains possibly credit
+                        card number, last 5 digits
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -56,7 +57,9 @@ class IPPOLBAccount
      */
     public $AccountDetails;
     /**
-     * @Definition True when the AccountId is linked to an IPP app and false when the AccountId is delinked from the IPP app
+     * @Definition True when the AccountId is linked to an IPP app
+                        and false when the AccountId is delinked from the IPP app
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -65,7 +68,8 @@ class IPPOLBAccount
      */
     public $SubscribedToApp;
     /**
-     * @Definition Specifies which version is being used (such as v1 or v2). This field is optional.
+     * @Definition Specifies which version is being used (such as v1
+                        or v2). This field is optional.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -75,6 +79,7 @@ class IPPOLBAccount
     public $AppVersion;
     /**
      * @Definition The last bank balance. This field is optional.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPOLBStatus.php
+++ b/src/Data/IPPOLBStatus.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType
  * @xmlName IPPOLBStatus
  * @var IPPOLBStatus
- * @xmlDefinition Describes list of OLBAccounts that needs to be enabled or disabled
+ * @xmlDefinition Describes list of OLBAccounts that needs to be
+                enabled or disabled
  */
 class IPPOLBStatus
 {
@@ -20,20 +21,20 @@ class IPPOLBStatus
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPOLBStatus', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPOLBStatus', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPOLBStatus', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPOLBStatus', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPOLBTransaction.php
+++ b/src/Data/IPPOLBTransaction.php
@@ -7,6 +7,7 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPOLBTransaction
  * @var IPPOLBTransaction
  * @xmlDefinition Describes OLBTransactions list that are downloaded
+
  */
 class IPPOLBTransaction
 {
@@ -20,20 +21,20 @@ class IPPOLBTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPOLBTransaction', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPOLBTransaction', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPOLBTransaction', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPOLBTransaction', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPOLBTxn.php
+++ b/src/Data/IPPOLBTxn.php
@@ -7,6 +7,7 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPOLBTxn
  * @var IPPOLBTxn
  * @xmlDefinition Describes OLBTransactions list that are downloaded
+
  */
 class IPPOLBTxn
 {
@@ -20,20 +21,20 @@ class IPPOLBTxn
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPOLBTxn', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPOLBTxn', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPOLBTxn', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPOLBTxn', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
@@ -49,7 +50,8 @@ class IPPOLBTxn
     /**
      * @Definition
                         Product: ALL
-                        Description: Last Posting date of OLB transactions where downloaded from the bank
+                        Description: Last Posting date of OLB transactions where downloaded from the
+                        bank
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -82,6 +84,7 @@ class IPPOLBTxn
     public $OLBTxnDetail;
     /**
      * @Definition Specifies the starting row number in this result
+
      * @xmlType attribute
      * @xmlName startPosition
      * @var integer
@@ -89,13 +92,15 @@ class IPPOLBTxn
     public $startPosition;
     /**
      * @Definition Specifies the number of records in this result
+
      * @xmlType attribute
      * @xmlName maxResults
      * @var integer
      */
     public $maxResults;
     /**
-     * @Definition Specifies the total count of records that satisfy the filter condition
+     * @Definition Specifies the total count of records that satisfy
+                    the filter condition
      * @xmlType attribute
      * @xmlName totalCount
      * @var integer

--- a/src/Data/IPPOLBTxnDetail.php
+++ b/src/Data/IPPOLBTxnDetail.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType
  * @xmlName IPPOLBTxnDetail
  * @var IPPOLBTxnDetail
- * @xmlDefinition Describes OLBTransaction instance - one per transaction downloaded
+ * @xmlDefinition Describes OLBTransaction instance - one per
+                transaction downloaded
  */
 class IPPOLBTxnDetail
 {
@@ -20,20 +21,20 @@ class IPPOLBTxnDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPOLBTxnDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPOLBTxnDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPOLBTxnDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPOLBTxnDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition Post date of the transaction
      * @xmlType element
@@ -63,6 +64,7 @@ class IPPOLBTxnDetail
     public $Amount;
     /**
      * @Definition Reference Number of downloaded transaction
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -71,7 +73,9 @@ class IPPOLBTxnDetail
      */
     public $ReferenceNumber;
     /**
-     * @Definition Olb Status of a transaction, Use OLBTransactionStausEnum Approved/Pending/Deleted
+     * @Definition Olb Status of a transaction, Use
+                        OLBTransactionStausEnum Approved/Pending/Deleted
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPOLBTxnStatusEnum.php
+++ b/src/Data/IPPOLBTxnStatusEnum.php
@@ -7,7 +7,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPOLBTxnStatusEnum
  * @var IPPOLBTxnStatusEnum
  * @xmlDefinition  Product: All
-                Description: Enumeration of  OLBTransactions Status
+                Description: Enumeration of
+                OLBTransactions Status
+
  */
 class IPPOLBTxnStatusEnum
 {
@@ -21,22 +23,22 @@ class IPPOLBTxnStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPOLBTxnStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPOLBTxnStatusEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPOLBTxnStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPOLBTxnStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPOLBTxnStatusEnum

--- a/src/Data/IPPOperationEnum.php
+++ b/src/Data/IPPOperationEnum.php
@@ -11,31 +11,35 @@ namespace QuickBooksOnline\API\Data;
 class IPPOperationEnum
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPOperationEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPOperationEnum', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPOperationEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPOperationEnum', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
+    }//end __construct()
+
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
-} // end class IPPOperationEnum
+    public $value;
+}//end class
+
+ // end class IPPOperationEnum

--- a/src/Data/IPPOtherName.php
+++ b/src/Data/IPPOtherName.php
@@ -20,20 +20,20 @@ class IPPOtherName extends IPPNameBase
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPOtherName', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPOtherName', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPOtherName', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPOtherName', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition Name or number of the account associated with this other name (payee).
                                 Length Restriction:

--- a/src/Data/IPPOtherPrefs.php
+++ b/src/Data/IPPOtherPrefs.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType
  * @xmlName IPPOtherPrefs
  * @var IPPOtherPrefs
- * @xmlDefinition Any other preference not covered in base is covered as name value pair, for detailed explanation look at the document
+ * @xmlDefinition Any other preference not covered in base is covered
+                as name value pair, for detailed explanation look at the document
+
  */
 class IPPOtherPrefs
 {
@@ -20,22 +22,24 @@ class IPPOtherPrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPOtherPrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPOtherPrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPOtherPrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPOtherPrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition  Specifies extension of Preference entity to allow extension of Name-Value pair based extension at the top level
+     * @Definition  Specifies extension of Preference entity to
+                        allow extension of Name-Value pair based extension at the top
+                        level
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPPaySalesTaxEnum.php
+++ b/src/Data/IPPPaySalesTaxEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPaySalesTaxEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of sales tax payment basis.
+                Description: Enumeration of sales tax
+                payment basis.
 
  */
 class IPPPaySalesTaxEnum
@@ -23,22 +24,22 @@ class IPPPaySalesTaxEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPaySalesTaxEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPaySalesTaxEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPaySalesTaxEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPaySalesTaxEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPPaySalesTaxEnum

--- a/src/Data/IPPPayment.php
+++ b/src/Data/IPPPayment.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType Transaction
  * @xmlName IPPPayment
  * @var IPPPayment
- * @xmlDefinition Financial transaction representing a payment from a customer applied to one or more sales transactions
+ * @xmlDefinition Financial transaction representing a payment from a
+                customer applied to one or more sales transactions
+
  */
 class IPPPayment extends IPPTransaction
 {
@@ -20,24 +22,25 @@ class IPPPayment extends IPPTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPayment', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPayment', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPayment', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPayment', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL
-                                Description: Represents Customer (or Job)Reference
+                                Description: Represents Customer
+                                (or Job)Reference
                                 Filterable: QBW
 
      * @xmlType element
@@ -48,8 +51,10 @@ class IPPPayment extends IPPTransaction
      */
     public $CustomerRef;
     /**
-     * @Definition Identifies the party or location that the payment is to be remitted to or sent to.
-                                [b]QuickBooks Notes[/b][br /]
+     * @Definition Identifies the party or location that the
+                                payment is to be remitted to or sent to.
+                                [b]QuickBooks
+                                Notes[/b][br /]
                                 Non QB-writable.
 
      * @xmlType element
@@ -60,9 +65,13 @@ class IPPPayment extends IPPTransaction
      */
     public $RemitToRef;
     /**
-     * @Definition ARAccountReferenceGroup Identifies the AR Account to be used for this Payment.
-                                [b]QuickBooks Notes[/b][br /]
-                                The AR Account should always be specified or a default will be used.
+     * @Definition ARAccountReferenceGroup Identifies the AR
+                                Account to be used for this Payment.
+                                [b]QuickBooks Notes[/b][br
+                                /]
+                                The AR Account should always be specified or a default will be
+                                used.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -71,9 +80,12 @@ class IPPPayment extends IPPTransaction
      */
     public $ARAccountRef;
     /**
-     * @Definition Optional asset account specification to designate the account the payment money needs to be deposited to.
+     * @Definition Optional asset account specification to
+                                designate the account the payment money needs to be deposited
+                                to.
                                 [b]QuickBooks Notes[/b][br /]
-                                If not specified, the Undeposited Funds account will be used.
+                                If not specified, the
+                                Undeposited Funds account will be used.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -85,7 +97,8 @@ class IPPPayment extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the PaymentMethod.
+                                Description: Reference to the
+                                PaymentMethod.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -97,7 +110,10 @@ class IPPPayment extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: The reference number for the payment received (I.e. Check # for a check, envelope # for a cash donation, CreditCardTransactionID for a credit card payment)
+                                Description: The reference number
+                                for the payment received (I.e. Check # for a check, envelope #
+                                for a cash donation, CreditCardTransactionID for a credit card
+                                payment)
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -109,7 +125,10 @@ class IPPPayment extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: Valid values are Cash, Check, CreditCard, or Other. No defaults. Cash based expense is not supported by QuickBooks Windows. Not applicable to Estimate and SalesOrder.[br /]
+                                Description: Valid values are Cash, Check, CreditCard, or
+                                Other. No defaults. Cash based expense is not supported by
+                                QuickBooks Windows. Not applicable to Estimate and
+                                SalesOrder.[br /]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -137,8 +156,11 @@ class IPPPayment extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: Indicates the total amount of the entity associated. This includes the total of all the payments from the Payment Details.
-                                [b]QuickBooks Notes[/b][br /]
+                                Description: Indicates the total
+                                amount of the entity associated. This includes the total of all
+                                the payments from the Payment Details.
+                                [b]QuickBooks Notes[/b][br
+                                /]
                                 Non QB-writable.
                                 Filterable: QBW
                                 Sortable: QBW
@@ -151,8 +173,10 @@ class IPPPayment extends IPPTransaction
      */
     public $TotalAmt;
     /**
-     * @Definition Indicates the amount that has not been applied to pay amounts owed for sales transactions.
-                                [b]QuickBooks Notes[/b][br /]
+     * @Definition Indicates the amount that has not been applied
+                                to pay amounts owed for sales transactions.
+                                [b]QuickBooks
+                                Notes[/b][br /]
                                 Non QB-writable.
 
      * @xmlType element
@@ -163,7 +187,9 @@ class IPPPayment extends IPPTransaction
      */
     public $UnappliedAmt;
     /**
-     * @Definition Indicates that the payment should be processed by merchant account service. Valid for QBO companies with credit card processing.
+     * @Definition Indicates that the payment should be processed
+                                by merchant account service. Valid for QBO companies with credit
+                                card processing.
                                 QBO only field.
 
      * @xmlType element
@@ -174,7 +200,8 @@ class IPPPayment extends IPPTransaction
      */
     public $ProcessPayment;
     /**
-     * @Definition Internal use only: extension place holder for Payment
+     * @Definition Internal use only: extension place holder for
+                                Payment
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPPaymentLineDetail.php
+++ b/src/Data/IPPPaymentLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPaymentLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: Payment detail for a transaction line.
+                Description: Payment detail for a
+                transaction line.
 
  */
 class IPPPaymentLineDetail
@@ -23,24 +24,27 @@ class IPPPaymentLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPaymentLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPaymentLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPaymentLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPaymentLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the Item. When a line lacks an ItemRef it will be treated as "documentation" and the Amount will be ignored.
+                        Description: Reference to the Item.
+                        When a line lacks an ItemRef it will be treated as "documentation"
+                        and the Amount will be ignored.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlName ItemRef
@@ -50,7 +54,8 @@ class IPPPaymentLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Date when the service is performed.
+                        Description: Date when the service is
+                        performed.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -62,7 +67,9 @@ class IPPPaymentLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the Class for the line item.
+                        Description: Reference to the Class
+                        for the line item.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -73,7 +80,9 @@ class IPPPaymentLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Indicates the unpaid amount of the transaction after this payment is applied.[br /]Cannot be written to QuickBooks.
+                        Description: Indicates the unpaid
+                        amount of the transaction after this payment is applied.[br
+                        /]Cannot be written to QuickBooks.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -85,7 +94,10 @@ class IPPPaymentLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Indicates the unpaid amount of the transaction after this payment is applied in home currency. It is visible only for companies which have multicurrency enabled[br /] Cannot be written to Quickbooks.
+                        Description: Indicates the unpaid
+                        amount of the transaction after this payment is applied in home
+                        currency. It is visible only for companies which have
+                        multicurrency enabled[br /] Cannot be written to Quickbooks.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -97,7 +109,9 @@ class IPPPaymentLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to a Discount item and its properties that this line can overwrite.
+                        Description: Reference to a Discount
+                        item and its properties that this line can overwrite.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -108,7 +122,8 @@ class IPPPaymentLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Internal use only: extension place holder for PaymentDetail
+                        Description: Internal use only:
+                        extension place holder for PaymentDetail
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPPaymentMethod.php
+++ b/src/Data/IPPPaymentMethod.php
@@ -7,6 +7,7 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPPaymentMethod
  * @var IPPPaymentMethod
  * @xmlDefinition Method of payment for received goods.
+
  */
 class IPPPaymentMethod extends IPPIntuitEntity
 {
@@ -20,22 +21,23 @@ class IPPPaymentMethod extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPaymentMethod', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPaymentMethod', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPaymentMethod', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPaymentMethod', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition User recognizable name for the payment method.[br /]
+     * @Definition User recognizable name for the payment
+                                method.[br /]
                                 Length Restriction:
                                 QBO: 15
                                 QBW: 31
@@ -48,8 +50,10 @@ class IPPPaymentMethod extends IPPIntuitEntity
      */
     public $Name;
     /**
-     * @Definition Whether or not active inactive payment methods may be hidden from most display purposes and may not be used on financial transactions.
-                            Filterable: QBW
+     * @Definition Whether or not active inactive payment methods
+                                may be hidden from most display purposes and may not be used on
+                                financial transactions.
+                                Filterable: QBW
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -59,7 +63,10 @@ class IPPPaymentMethod extends IPPIntuitEntity
      */
     public $Active;
     /**
-     * @Definition Defines the type, or the ways the payment was made. For QBW, the acceptable values are defined in PaymentMethodEnum.  For QBO, this field is restricted to CREDIT_CARD or NON_CREDIT_CARD.
+     * @Definition Defines the type, or the ways the payment was
+                                made. For QBW, the acceptable values are defined in
+                                PaymentMethodEnum. For QBO, this field is restricted to
+                                CREDIT_CARD or NON_CREDIT_CARD.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -68,7 +75,8 @@ class IPPPaymentMethod extends IPPIntuitEntity
      */
     public $Type;
     /**
-     * @Definition Internal use only: extension place holder for PaymentMethod
+     * @Definition Internal use only: extension place holder for
+                                PaymentMethod
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPPaymentMethodEnum.php
+++ b/src/Data/IPPPaymentMethodEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPaymentMethodEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of payment methods when receiving a customer payment of paying for goods.
+                Description: Enumeration of payment
+                methods when receiving a customer payment of paying for goods.
 
  */
 class IPPPaymentMethodEnum
@@ -23,22 +24,22 @@ class IPPPaymentMethodEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPaymentMethodEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPaymentMethodEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPaymentMethodEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPaymentMethodEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPPaymentMethodEnum

--- a/src/Data/IPPPaymentStatusEnum.php
+++ b/src/Data/IPPPaymentStatusEnum.php
@@ -8,7 +8,13 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPaymentStatusEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of payable status for an invoice, as follows: A pending invoice is not yet approved/final/sent; not yet payable by customer. A payable invoice is now payable.  Partial payments may have been received, but money still remains to be paid.  No claim is made about due vs. overdue, past due etc... A paid invoice has been paid in full.  No amount remains to be paid.
+                Description: Enumeration of payable
+                status for an invoice, as follows: A pending invoice is not yet
+                approved/final/sent; not yet payable by customer. A payable invoice
+                is now payable. Partial payments may have been received, but money
+                still remains to be paid. No claim is made about due vs. overdue,
+                past due etc... A paid invoice has been paid in full. No amount
+                remains to be paid.
 
  */
 class IPPPaymentStatusEnum
@@ -23,22 +29,22 @@ class IPPPaymentStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPaymentStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPaymentStatusEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPaymentStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPaymentStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPPaymentStatusEnum

--- a/src/Data/IPPPaymentTypeEnum.php
+++ b/src/Data/IPPPaymentTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPaymentTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of payment types.
+                Description: Enumeration of payment
+                types.
 
  */
 class IPPPaymentTypeEnum
@@ -23,22 +24,22 @@ class IPPPaymentTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPaymentTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPaymentTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPaymentTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPaymentTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPPaymentTypeEnum

--- a/src/Data/IPPPerItemAdjustEnum.php
+++ b/src/Data/IPPPerItemAdjustEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPerItemAdjustEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of per item adjustments.
+                Description: Enumeration of per item
+                adjustments.
 
  */
 class IPPPerItemAdjustEnum
@@ -23,22 +24,22 @@ class IPPPerItemAdjustEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPerItemAdjustEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPerItemAdjustEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPerItemAdjustEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPerItemAdjustEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPPerItemAdjustEnum

--- a/src/Data/IPPPhysicalAddress.php
+++ b/src/Data/IPPPhysicalAddress.php
@@ -23,21 +23,20 @@ class IPPPhysicalAddress
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                //If the NameSpace is added, then
-                if (property_exists('QuickBooksOnline\API\Data\IPPPhysicalAddress', $initPropName) || property_exists('IPPPhysicalAddress', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPhysicalAddress', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPhysicalAddress', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPPhysicalAddressTypeEnum.php
+++ b/src/Data/IPPPhysicalAddressTypeEnum.php
@@ -23,22 +23,22 @@ class IPPPhysicalAddressTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPhysicalAddressTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPhysicalAddressTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPhysicalAddressTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPhysicalAddressTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPPhysicalAddressTypeEnum

--- a/src/Data/IPPPostingTypeEnum.php
+++ b/src/Data/IPPPostingTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPostingTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of QuickBooks posting types.
+                Description: Enumeration of QuickBooks
+                posting types.
 
  */
 class IPPPostingTypeEnum
@@ -23,22 +24,22 @@ class IPPPostingTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPostingTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPostingTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPostingTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPostingTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPPostingTypeEnum

--- a/src/Data/IPPPreferences.php
+++ b/src/Data/IPPPreferences.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType IntuitEntity
  * @xmlName IPPPreferences
  * @var IPPPreferences
- * @xmlDefinition Defines Preference strongly typed object with extensions
+ * @xmlDefinition Defines Preference strongly typed object with
+                extensions
  */
 class IPPPreferences extends IPPIntuitEntity
 {
@@ -20,20 +21,20 @@ class IPPPreferences extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPreferences', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPreferences', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPreferences', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPreferences', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition Accounting info Preferences
      * @xmlType element
@@ -54,6 +55,7 @@ class IPPPreferences extends IPPIntuitEntity
     public $AdvancedInventoryPrefs;
     /**
      * @Definition Product and Service Preferences
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -81,6 +83,7 @@ class IPPPreferences extends IPPIntuitEntity
     public $EmailMessagesPrefs;
     /**
      * @Definition Printable document preferences
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -90,6 +93,7 @@ class IPPPreferences extends IPPIntuitEntity
     public $PrintDocumentPrefs;
     /**
      * @Definition Vendor and purchases Preferences
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -99,6 +103,7 @@ class IPPPreferences extends IPPIntuitEntity
     public $VendorAndPurchasesPrefs;
     /**
      * @Definition Vendor and purchases Preferences
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -143,7 +148,9 @@ class IPPPreferences extends IPPIntuitEntity
      */
     public $ReportPrefs;
     /**
-     * @Definition  Specifies extension of Preference entity to allow extension of Name-Value pair based extension at the top level
+     * @Definition  Specifies extension of Preference entity to
+                                allow extension of Name-Value pair based extension at the top
+                                level
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPPriceLevel.php
+++ b/src/Data/IPPPriceLevel.php
@@ -8,7 +8,18 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPriceLevel
  * @xmlDefinition
                 Product: QBW
-                Description: You can use price levels to specify custom pricing for specific customers. Once you create a price level for a customer, QuickBooks will automatically use the custom price in new invoices, sales receipts, sales orders or credit memos for that customer. You can override this automatic feature, however, when you create the invoices, sales receipts, etc. The user can now specify a price level on line items in the following supported sales transactions: invoices, sales receipts, credit memos, and sales orders. Notice that the response data for the affected sales transaction does not list the price level that was used. The response simply lists the Rate for the item, which was set using the price level.
+                Description: You can use price levels
+                to specify custom pricing for specific customers. Once you create a
+                price level for a customer, QuickBooks will automatically use the
+                custom price in new invoices, sales receipts, sales orders or credit
+                memos for that customer. You can override this automatic feature,
+                however, when you create the invoices, sales receipts, etc. The user
+                can now specify a price level on line items in the following
+                supported sales transactions: invoices, sales receipts, credit
+                memos, and sales orders. Notice that the response data for the
+                affected sales transaction does not list the price level that was
+                used. The response simply lists the Rate for the item, which was set
+                using the price level.
 
  */
 class IPPPriceLevel extends IPPIntuitEntity
@@ -23,24 +34,25 @@ class IPPPriceLevel extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPriceLevel', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPriceLevel', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPriceLevel', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPriceLevel', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBW
-                                Description: User-visible name of the price level
+                                Description: User-visible name of
+                                the price level
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +76,10 @@ class IPPPriceLevel extends IPPIntuitEntity
     /**
      * @Definition
                                     Product: QBW
-                                    Description: A positive value would increase the price by the given percentage, a negative value would decrease the base price by the given percentage.  All prices are changed by the same given percentage.
+                                    Description: A positive value
+                                    would increase the price by the given percentage, a negative
+                                    value would decrease the base price by the given percentage.
+                                    All prices are changed by the same given percentage.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -75,7 +90,8 @@ class IPPPriceLevel extends IPPIntuitEntity
     /**
      * @Definition
                                     Product: QBW
-                                    Description: A list of items and the price or price percentage that applies to the item
+                                    Description: A list of items and
+                                    the price or price percentage that applies to the item
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -88,7 +104,8 @@ class IPPPriceLevel extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: Reference to the currency in which the price level is expressed.
+                                Description: Reference to the
+                                currency in which the price level is expressed.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -98,7 +115,8 @@ class IPPPriceLevel extends IPPIntuitEntity
      */
     public $CurrencyRef;
     /**
-     * @Definition Internal use only: extension place holder for PriceLevel
+     * @Definition Internal use only: extension place holder for
+                                PriceLevel
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPPriceLevelPerItem.php
+++ b/src/Data/IPPPriceLevelPerItem.php
@@ -8,7 +8,9 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPriceLevelPerItem
  * @xmlDefinition
                 Product: QBW
-                Description: A custom price or percentage change from the item's base price for a specific price level
+                Description: A custom price or
+                percentage change from the item's base price for a specific price
+                level
 
  */
 class IPPPriceLevelPerItem extends IPPIntuitEntity
@@ -23,20 +25,20 @@ class IPPPriceLevelPerItem extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPriceLevelPerItem', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPriceLevelPerItem', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPriceLevelPerItem', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPriceLevelPerItem', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -48,7 +50,8 @@ class IPPPriceLevelPerItem extends IPPIntuitEntity
     /**
      * @Definition
                                     Product: QBW
-                                    Description: A specific price for the given item.
+                                    Description: A specific price for
+                                    the given item.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -60,7 +63,10 @@ class IPPPriceLevelPerItem extends IPPIntuitEntity
     /**
      * @Definition
                                     Product: QBW
-                                    Description: Modifies the base selling price of the given item by the specified percentage.  A positive value increases the price, a negative value reduces the price.
+                                    Description: Modifies the base
+                                    selling price of the given item by the specified percentage. A
+                                    positive value increases the price, a negative value reduces
+                                    the price.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -70,7 +76,8 @@ class IPPPriceLevelPerItem extends IPPIntuitEntity
      */
     public $CustomPricePercent;
     /**
-     * @Definition Internal use only: extension place holder for PriceLevelPerItem
+     * @Definition Internal use only: extension place holder for
+                                PriceLevelPerItem
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPPriceLevelTypeEnum.php
+++ b/src/Data/IPPPriceLevelTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPriceLevelTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of price level types.
+                Description: Enumeration of price level
+                types.
 
  */
 class IPPPriceLevelTypeEnum
@@ -23,22 +24,22 @@ class IPPPriceLevelTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPriceLevelTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPriceLevelTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPriceLevelTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPriceLevelTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPPriceLevelTypeEnum

--- a/src/Data/IPPPrintDocumentPrefs.php
+++ b/src/Data/IPPPrintDocumentPrefs.php
@@ -20,22 +20,23 @@ class IPPPrintDocumentPrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPrintDocumentPrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPrintDocumentPrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPrintDocumentPrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPrintDocumentPrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition  Specifies Preferences classified as email messages are classified as Name-Value pair
+     * @Definition  Specifies Preferences classified as email
+                        messages are classified as Name-Value pair
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPPrintStatusEnum.php
+++ b/src/Data/IPPPrintStatusEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPrintStatusEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of print status values.
+                Description: Enumeration of print
+                status values.
 
  */
 class IPPPrintStatusEnum
@@ -23,22 +24,22 @@ class IPPPrintStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPrintStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPrintStatusEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPrintStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPrintStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPPrintStatusEnum

--- a/src/Data/IPPProductAndServicesPrefs.php
+++ b/src/Data/IPPProductAndServicesPrefs.php
@@ -7,6 +7,7 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPProductAndServicesPrefs
  * @var IPPProductAndServicesPrefs
  * @xmlDefinition Defines Product and Services Prefs details
+
  */
 class IPPProductAndServicesPrefs
 {
@@ -20,24 +21,25 @@ class IPPProductAndServicesPrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPProductAndServicesPrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPProductAndServicesPrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPProductAndServicesPrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPProductAndServicesPrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product:QBO
                         ProductAndServices for Sales enabled
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -48,7 +50,9 @@ class IPPProductAndServicesPrefs
     /**
      * @Definition
                         Product:QBO
-                        ProductAndServices for purchases enabled
+                        ProductAndServices for purchases
+                        enabled
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -60,6 +64,7 @@ class IPPProductAndServicesPrefs
      * @Definition
                         Product:QBW
                         Inventory and PO are active
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -70,7 +75,9 @@ class IPPProductAndServicesPrefs
     /**
      * @Definition
                         Product:QBO
-                        Enable quantity with price and rate enabled
+                        Enable quantity with price and rate
+                        enabled
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -82,6 +89,7 @@ class IPPProductAndServicesPrefs
      * @Definition
                         Product:QBO
                         Enable QuantityOnHand enabled
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -90,7 +98,8 @@ class IPPProductAndServicesPrefs
      */
     public $QuantityOnHand;
     /**
-     * @Definition Product:QBW. Possible values are Disabled,SinglePerItem and MultiplePerItem
+     * @Definition Product:QBW. Possible values are
+                        Disabled,SinglePerItem and MultiplePerItem
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPPurchase.php
+++ b/src/Data/IPPPurchase.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType Transaction
  * @xmlName IPPPurchase
  * @var IPPPurchase
- * @xmlDefinition The reference to the purchase transaction which is being paid by this check.
+ * @xmlDefinition The reference to the purchase transaction which
+                                is being paid by this check.
                                 [b]QuickBooks Notes[/b][br /]
                                 [i]Unsupported field.[/i]
 
@@ -23,22 +24,23 @@ class IPPPurchase extends IPPTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPurchase', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPurchase', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPurchase', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPurchase', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition Specifies the account reference. Check should have bank account, CreditCard should specify credit card account
+     * @Definition Specifies the account reference. Check should
+                                have bank account, CreditCard should specify credit card account
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -50,7 +52,8 @@ class IPPPurchase extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the PaymentMethod.
+                                Description: Reference to the
+                                PaymentMethod.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -62,7 +65,10 @@ class IPPPurchase extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: The reference number for the payment received (I.e. Check # for a check, envelope # for a cash donation, CreditCardTransactionID for a credit card payment)
+                                Description: The reference number
+                                for the payment received (I.e. Check # for a check, envelope #
+                                for a cash donation, CreditCardTransactionID for a credit card
+                                payment)
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -72,8 +78,10 @@ class IPPPurchase extends IPPTransaction
      */
     public $PaymentRefNum;
     /**
-     * @Definition  Required element. No defaults. Expense Type can be Cash, Check or CreditCard
-                                Cash based expense is not supported by QBW.
+     * @Definition  Required element. No defaults. Expense Type
+                                can be Cash, Check or CreditCard
+                                Cash based expense is not
+                                supported by QBW.
                                 Filterable: QBW
 
      * @xmlType element
@@ -100,7 +108,9 @@ class IPPPurchase extends IPPTransaction
      */
     public $CreditCardPayment;
     /**
-     * @Definition Specifies the party to whom a expense is associated with. Can be Customer, Vendor, Employee (or OtherName in case of QBW)
+     * @Definition Specifies the party to whom a expense is
+                                associated with. Can be Customer, Vendor, Employee (or OtherName
+                                in case of QBW)
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -110,8 +120,10 @@ class IPPPurchase extends IPPTransaction
      */
     public $EntityRef;
     /**
-     * @Definition If Credit is Null or False, it is considered as Charge. If true, the CreditCard represents a Refund. Valid only for CreditCard transaction
-                            Filterable: QBW
+     * @Definition If Credit is Null or False, it is considered as
+                                Charge. If true, the CreditCard represents a Refund. Valid only
+                                for CreditCard transaction
+                                Filterable: QBW
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -121,7 +133,8 @@ class IPPPurchase extends IPPTransaction
      */
     public $Credit;
     /**
-     * @Definition Address to which the payment should be sent.Output only.
+     * @Definition Address to which the payment should be
+                                sent.Output only.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -131,11 +144,15 @@ class IPPPurchase extends IPPTransaction
      */
     public $RemitToAddr;
     /**
-     * @Definition The total amount due, determined by taking the sum of all lines associated.  This includes all charges, allowances, taxes, discounts, etc...
-                                [b]QuickBooks Notes[/b][br /]
+     * @Definition The total amount due, determined by taking the
+                                sum of all lines associated. This includes all charges,
+                                allowances, taxes, discounts, etc...
+                                [b]QuickBooks Notes[/b][br
+                                /]
                                 Non QB-writable.
                                 Output only field in case of QBO
-                                Filterable: QBW
+                                Filterable:
+                                QBW
                                 Sortable: QBW
 
      * @xmlType element
@@ -146,7 +163,9 @@ class IPPPurchase extends IPPTransaction
      */
     public $TotalAmt;
     /**
-     * @Definition Memo that will be printed in check in case of Check purchase, Memo appears on the expense report for CreditCard, Memo for CashPurchase
+     * @Definition Memo that will be printed in check in case of
+                                Check purchase, Memo appears on the expense report for
+                                CreditCard, Memo for CashPurchase
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -156,7 +175,8 @@ class IPPPurchase extends IPPTransaction
      */
     public $Memo;
     /**
-     * @Definition PrintStatus if to be printed or already printed information
+     * @Definition PrintStatus if to be printed or already printed
+                                information
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -168,7 +188,9 @@ class IPPPurchase extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Indicates the GlobalTax model if the model inclusive of tax, exclusive of taxes or not applicable
+                                Description: Indicates the
+                                GlobalTax model if the model inclusive of tax, exclusive of
+                                taxes or not applicable
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -178,7 +200,8 @@ class IPPPurchase extends IPPTransaction
      */
     public $GlobalTaxCalculation;
     /**
-     * @Definition Internal use only: extension place holder for Purchase.
+     * @Definition Internal use only: extension place holder for
+                                Purchase.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPPurchaseByVendor.php
+++ b/src/Data/IPPPurchaseByVendor.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType Transaction
  * @xmlName IPPPurchaseByVendor
  * @var IPPPurchaseByVendor
- * @xmlDefinition Financial Transaction information that pertains to the entire Bill.
+ * @xmlDefinition Financial Transaction information that pertains to
+                the entire Bill.
  */
 class IPPPurchaseByVendor extends IPPTransaction
 {
@@ -20,25 +21,25 @@ class IPPPurchaseByVendor extends IPPTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPurchaseByVendor', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPurchaseByVendor', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPurchaseByVendor', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPurchaseByVendor', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
-                            Product: ALL
-                            Description: Specifies the vendor reference for this transaction
-                            Filterable: QBW
+                                Product: ALL
+                                Description: Specifies the vendor reference for this transaction
+                                Filterable: QBW
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -48,9 +49,14 @@ class IPPPurchaseByVendor extends IPPTransaction
      */
     public $VendorRef;
     /**
-     * @Definition Specifies which AP account the bill will be credited to. Many/most small businesses have a single AP account, so the account is implied.  When specified, the account must be a Liability account, and further, the sub-type must be of type "Payables"
+     * @Definition Specifies which AP account the bill will be
+                                credited to. Many/most small businesses have a single AP
+                                account, so the account is implied. When specified, the account
+                                must be a Liability account, and further, the sub-type must be
+                                of type "Payables"
                                 [b]QuickBooks Notes[/b][br /]
-                                The AP Account should always be specified or a default will be used.
+                                The AP Account
+                                should always be specified or a default will be used.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -61,13 +67,15 @@ class IPPPurchaseByVendor extends IPPTransaction
     public $APAccountRef;
     /**
      * @Definition
-                            Product: ALL
-                            Description: The total amount due, determined by taking the sum of all lines associated.  This includes all charges, allowances, taxes, discounts, etc...
+                                Product: ALL
+                                Description: The total amount due, determined by taking the sum of all lines
+                                associated. This includes all charges, allowances, taxes,
+                                discounts, etc...
                                 [b]QuickBooks Notes[/b][br /]
                                 Non QB-writable.
                                 Output only field in case of QBO
-                            Filterable: QBW
-                            Sortable: QBW
+                                Filterable: QBW
+                                Sortable: QBW
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -79,7 +87,8 @@ class IPPPurchaseByVendor extends IPPTransaction
     /**
      * @Definition
                                 Product: QBW
-                                Description: The email address to which this bill is/was sent. [br/] Non QB-writable.
+                                Description: The email address to
+                                which this bill is/was sent. [br/] Non QB-writable.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -91,7 +100,9 @@ class IPPPurchaseByVendor extends IPPTransaction
     /**
      * @Definition
                                 Product: QBW
-                                Description: The email address to which inquiries about the bill may be directed. (Also appropriate for paypal payments). [br/] Non QB-writable.
+                                Description: The email address to
+                                which inquiries about the bill may be directed. (Also
+                                appropriate for paypal payments). [br/] Non QB-writable.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -113,7 +124,9 @@ class IPPPurchaseByVendor extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Indicates the GlobalTax model if the model inclusive of tax, exclusive of taxes or not applicable
+                                Description: Indicates the
+                                GlobalTax model if the model inclusive of tax, exclusive of
+                                taxes or not applicable
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPPurchaseOrder.php
+++ b/src/Data/IPPPurchaseOrder.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType PurchaseByVendor
  * @xmlName IPPPurchaseOrder
  * @var IPPPurchaseOrder
- * @xmlDefinition PurchaseOrder is a non-posting transaction representing a request to purchase goods or services from a third party.
+ * @xmlDefinition PurchaseOrder is a non-posting transaction
+                representing a request to purchase goods or services from a third
+                party.
  */
 class IPPPurchaseOrder extends IPPPurchaseByVendor
 {
@@ -20,22 +22,23 @@ class IPPPurchaseOrder extends IPPPurchaseByVendor
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPurchaseOrder', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPurchaseOrder', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPurchaseOrder', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPurchaseOrder', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition Represents the TaxCode Reference with respect to the purchase[br /]
+     * @Definition Represents the TaxCode Reference with respect
+                                to the purchase[br /]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -53,7 +56,9 @@ class IPPPurchaseOrder extends IPPPurchaseByVendor
      */
     public $ClassRef;
     /**
-     * @Definition Information about the Customer and actual Job or Project the expense must be reimbursed for.
+     * @Definition Information about the Customer and actual Job
+                                or Project the expense must be reimbursed for.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -70,7 +75,9 @@ class IPPPurchaseOrder extends IPPPurchaseByVendor
      */
     public $SalesTermRef;
     /**
-     * @Definition The nominal date by which the bill must be paid, not including any early-payment discount incentives, or late payment penalties.
+     * @Definition The nominal date by which the bill must be
+                                paid, not including any early-payment discount incentives, or
+                                late payment penalties.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -79,7 +86,8 @@ class IPPPurchaseOrder extends IPPPurchaseByVendor
      */
     public $DueDate;
     /**
-     * @Definition The date when the delivery of the product is expected.
+     * @Definition The date when the delivery of the product is
+                                expected.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -118,7 +126,8 @@ class IPPPurchaseOrder extends IPPPurchaseByVendor
      */
     public $InventorySiteRef;
     /**
-     * @Definition Address to which the vendor shipped or will ship any goods associated with the purchase.
+     * @Definition Address to which the vendor shipped or will
+                                ship any goods associated with the purchase.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -135,7 +144,9 @@ class IPPPurchaseOrder extends IPPPurchaseByVendor
      */
     public $ShipMethodRef;
     /**
-     * @Definition "Free On Board", specifies the terms between buyer and seller regarding transportation costs; does not have any bookkeeping implications.
+     * @Definition "Free On Board", specifies the terms between
+                                buyer and seller regarding transportation costs; does not have
+                                any bookkeeping implications.
                                 Length Restriction:
                                 QBO: 15
                                 QBW: 1024
@@ -148,7 +159,8 @@ class IPPPurchaseOrder extends IPPPurchaseByVendor
      */
     public $FOB;
     /**
-     * @Definition The email address to which this purchase order is/was sent.
+     * @Definition The email address to which this purchase order
+                                is/was sent.
                                 Length Restriction:
                                 QBO: 15
                                 QBW: 1024
@@ -185,7 +197,9 @@ class IPPPurchaseOrder extends IPPPurchaseByVendor
      */
     public $EmailStatus;
     /**
-     * @Definition The entire transaction, or individual items are manually closed, i.e. they may not be received.
+     * @Definition The entire transaction, or individual items are
+                                manually closed, i.e. they may not be received.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -202,7 +216,8 @@ class IPPPurchaseOrder extends IPPPurchaseByVendor
      */
     public $POStatus;
     /**
-     * @Definition Internal use only: extension place holder for PurchaseOrder
+     * @Definition Internal use only: extension place holder for
+                                PurchaseOrder
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPPurchaseOrderItemLineDetail.php
+++ b/src/Data/IPPPurchaseOrderItemLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPurchaseOrderItemLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: PurchaseOrder item detail for a transaction line.
+                Description: PurchaseOrder item detail
+                for a transaction line.
 
  */
 class IPPPurchaseOrderItemLineDetail extends IPPSalesItemLineDetail
@@ -23,24 +24,26 @@ class IPPPurchaseOrderItemLineDetail extends IPPSalesItemLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPurchaseOrderItemLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPurchaseOrderItemLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPurchaseOrderItemLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPurchaseOrderItemLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL
-                                Description: The identifier provided by manufacturer for the Item. For example, the model number.
+                                Description: The identifier
+                                provided by manufacturer for the Item. For example, the model
+                                number.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +55,9 @@ class IPPPurchaseOrderItemLineDetail extends IPPSalesItemLineDetail
     /**
      * @Definition
                                 Product: ALL
-                                Description: The item on the line is marked as if fully receiveded, but it is closed as no longer available.
+                                Description: The item on the line
+                                is marked as if fully receiveded, but it is closed as no longer
+                                available.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +69,9 @@ class IPPPurchaseOrderItemLineDetail extends IPPSalesItemLineDetail
     /**
      * @Definition
                                 Product: ALL
-                                Description: Represents the difference between the quantity ordered and actually received.[br /]Cannot be written to QuickBooks.
+                                Description: Represents the
+                                difference between the quantity ordered and actually
+                                received.[br /]Cannot be written to QuickBooks.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +83,8 @@ class IPPPurchaseOrderItemLineDetail extends IPPSalesItemLineDetail
     /**
      * @Definition
                                 Product: ALL
-                                Description: Internal use only: extension place holder for PurchaseOrderItemDetail
+                                Description: Internal use only:
+                                extension place holder for PurchaseOrderItemDetail
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPPurchaseOrderStatusEnum.php
+++ b/src/Data/IPPPurchaseOrderStatusEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPPurchaseOrderStatusEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of status for purchase order
+                Description: Enumeration of status for
+                purchase order
 
  */
 class IPPPurchaseOrderStatusEnum
@@ -23,22 +24,22 @@ class IPPPurchaseOrderStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPPurchaseOrderStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPPurchaseOrderStatusEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPPurchaseOrderStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPPurchaseOrderStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPPurchaseOrderStatusEnum

--- a/src/Data/IPPQbdtEntityIdMapping.php
+++ b/src/Data/IPPQbdtEntityIdMapping.php
@@ -7,8 +7,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPQbdtEntityIdMapping
  * @var IPPQbdtEntityIdMapping
  * @xmlDefinition Provides the mapping between ListId and TxnId in
-            Desktop to the same Entity Id in QBO. These mappings are available
-            for only companies that have migrated from Desktop to QBO
+                Desktop to the same Entity Id in QBO. These mappings are available
+                for only companies that have migrated from Desktop to QBO
 
  */
 class IPPQbdtEntityIdMapping extends IPPIntuitEntity
@@ -23,25 +23,25 @@ class IPPQbdtEntityIdMapping extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPQbdtEntityIdMapping', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPQbdtEntityIdMapping', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPQbdtEntityIdMapping', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPQbdtEntityIdMapping', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
-                            Product: QBO
-                            Description: The Id of the QBO Entity. This id is accepted by V3 APIs. They
-                            uniquely identify the entity in QBO for that company.
+                                Product: QBO
+                                Description: The Id of the QBO Entity. This id is accepted by V3 APIs. They
+                                uniquely identify the entity in QBO for that company.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -53,9 +53,9 @@ class IPPQbdtEntityIdMapping extends IPPIntuitEntity
     public $QboEntityId;
     /**
      * @Definition
-                            Product: QBO
-                            Description: The ListId or TxnId of the QB Desktop Entity. They uniquely
-                            identify the entity in QB Desktop for that company.
+                                Product: QBO
+                                Description: The ListId or TxnId of the QB Desktop Entity. They uniquely
+                                identify the entity in QB Desktop for that company.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -67,9 +67,9 @@ class IPPQbdtEntityIdMapping extends IPPIntuitEntity
     public $QbdtExportableId;
     /**
      * @Definition
-                            Product: QBO
-                            Description: The entity type name of the entity in QBO. Refer
-                            QboEntityTypeEnum for all the values.
+                                Product: QBO
+                                Description: The entity type name of the entity in QBO. Refer
+                                QboEntityTypeEnum for all the values.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -81,9 +81,9 @@ class IPPQbdtEntityIdMapping extends IPPIntuitEntity
     public $QboEntityType;
     /**
      * @Definition
-                            Product: QBO
-                            Description: The entity type name of the entity in QBO. Refer
-                            QbdtEntityTypeEnum for all the values.
+                                Product: QBO
+                                Description: The entity type name of the entity in QBO. Refer
+                                QbdtEntityTypeEnum for all the values.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPQboEntityTypeEnum.php
+++ b/src/Data/IPPQboEntityTypeEnum.php
@@ -7,6 +7,7 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPQboEntityTypeEnum
  * @var IPPQboEntityTypeEnum
  * @xmlDefinition Enumeration of Qbo Entity Type For AppId Migration
+
  */
 class IPPQboEntityTypeEnum
 {
@@ -20,22 +21,22 @@ class IPPQboEntityTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPQboEntityTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPQboEntityTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPQboEntityTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPQboEntityTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPQboEntityTypeEnum

--- a/src/Data/IPPQboEstimateStatusEnum.php
+++ b/src/Data/IPPQboEstimateStatusEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPQboEstimateStatusEnum
  * @xmlDefinition
                 Product: QBO
-                Description: Enumeration of status for an estimate in QuickBooks Online.
+                Description: Enumeration of status for
+                an estimate in QuickBooks Online.
 
  */
 class IPPQboEstimateStatusEnum
@@ -23,22 +24,22 @@ class IPPQboEstimateStatusEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPQboEstimateStatusEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPQboEstimateStatusEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPQboEstimateStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPQboEstimateStatusEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPQboEstimateStatusEnum

--- a/src/Data/IPPQueryResponse.php
+++ b/src/Data/IPPQueryResponse.php
@@ -12,26 +12,26 @@ class IPPQueryResponse
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPQueryResponse', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPQueryResponse', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPQueryResponse', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPQueryResponse', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
 
     /**

--- a/src/Data/IPPReferenceType.php
+++ b/src/Data/IPPReferenceType.php
@@ -23,20 +23,20 @@ class IPPReferenceType extends IPPid
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPReferenceType', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPReferenceType', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPReferenceType', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPReferenceType', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @xmlType attribute
      * @xmlName name

--- a/src/Data/IPPRefundReceipt.php
+++ b/src/Data/IPPRefundReceipt.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType SalesTransaction
  * @xmlName IPPRefundReceipt
  * @var IPPRefundReceipt
- * @xmlDefinition Financial transaction representing a refund (or credit) of payment or part of a payment for goods or services that have been sold.
+ * @xmlDefinition Financial transaction representing a refund (or
+                credit) of payment or part of a payment for goods or services that
+                have been sold.
  */
 class IPPRefundReceipt extends IPPSalesTransaction
 {
@@ -20,23 +22,25 @@ class IPPRefundReceipt extends IPPSalesTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPRefundReceipt', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPRefundReceipt', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPRefundReceipt', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPRefundReceipt', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition Indicates the total credit amount still available to apply towards the payment.
-                                [b]QuickBooks Notes[/b][br /]
+     * @Definition Indicates the total credit amount still
+                                available to apply towards the payment.
+                                [b]QuickBooks
+                                Notes[/b][br /]
                                 Non QB-writable.
 
      * @xmlType element
@@ -47,7 +51,8 @@ class IPPRefundReceipt extends IPPSalesTransaction
      */
     public $RemainingCredit;
     /**
-     * @Definition Internal use only: extension place holder for Refund
+     * @Definition Internal use only: extension place holder for
+                                Refund
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPReimbursableTypeEnum.php
+++ b/src/Data/IPPReimbursableTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPReimbursableTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of reimbursable status for purchased items/services.
+                Description: Enumeration of
+                reimbursable status for purchased items/services.
 
  */
 class IPPReimbursableTypeEnum
@@ -23,22 +24,22 @@ class IPPReimbursableTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPReimbursableTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPReimbursableTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPReimbursableTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPReimbursableTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPReimbursableTypeEnum

--- a/src/Data/IPPReimburseCharge.php
+++ b/src/Data/IPPReimburseCharge.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType Transaction
  * @xmlName IPPReimburseCharge
  * @var IPPReimburseCharge
- * @xmlDefinition  Product: QBO Description: Reimburse charge object for QBO
+ * @xmlDefinition  Product: QBO Description: Reimburse charge object
+                for QBO
 
  */
 class IPPReimburseCharge extends IPPTransaction
@@ -21,20 +22,20 @@ class IPPReimburseCharge extends IPPTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPReimburseCharge', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPReimburseCharge', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPReimburseCharge', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPReimburseCharge', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition  Product: QBO Description: Customer Reference
 

--- a/src/Data/IPPReport.php
+++ b/src/Data/IPPReport.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPReport
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPReport', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPReport', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPReport', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPReport', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition Report Header, contains the report options that were used to generate the report
@@ -43,6 +43,7 @@ class IPPReport
      * @var com\intuit\schema\finance\v3\IPPReportHeader
      */
     public $Header;
+
     /**
      * @Definition
      * @xmlType element
@@ -52,6 +53,7 @@ class IPPReport
      * @var com\intuit\schema\finance\v3\IPPColumns
      */
     public $Columns;
+
     /**
      * @Definition
      * @xmlType element
@@ -61,4 +63,6 @@ class IPPReport
      * @var com\intuit\schema\finance\v3\IPPRows
      */
     public $Rows;
-} // end class IPPReport
+}//end class
+
+ // end class IPPReport

--- a/src/Data/IPPReportBasisEnum.php
+++ b/src/Data/IPPReportBasisEnum.php
@@ -23,22 +23,22 @@ class IPPReportBasisEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPReportBasisEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPReportBasisEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPReportBasisEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPReportBasisEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPReportBasisEnum

--- a/src/Data/IPPReportHeader.php
+++ b/src/Data/IPPReportHeader.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPReportHeader
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPReportHeader', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPReportHeader', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPReportHeader', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPReportHeader', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition Specifies the time at which report was generated
@@ -43,6 +43,7 @@ class IPPReportHeader
      * @var string
      */
     public $Time;
+
     /**
      * @Definition Specifies the report name
      * @xmlType element
@@ -52,6 +53,7 @@ class IPPReportHeader
      * @var string
      */
     public $ReportName;
+
     /**
      * @Definition Specifies the report name
      * @xmlType element
@@ -61,6 +63,7 @@ class IPPReportHeader
      * @var string
      */
     public $DateMacro;
+
     /**
      * @Definition Specifies the report is cash basis or accrual basis
      * @xmlType element
@@ -70,6 +73,7 @@ class IPPReportHeader
      * @var com\intuit\schema\finance\v3\IPPReportBasisEnum
      */
     public $ReportBasis;
+
     /**
      * @Definition Start Period for which the report was generated
      * @xmlType element
@@ -79,6 +83,7 @@ class IPPReportHeader
      * @var string
      */
     public $StartPeriod;
+
     /**
      * @Definition End Period for which the report was generated
      * @xmlType element
@@ -88,6 +93,7 @@ class IPPReportHeader
      * @var string
      */
     public $EndPeriod;
+
     /**
      * @Definition Summarize columns by enumeration
      * @xmlType element
@@ -97,6 +103,7 @@ class IPPReportHeader
      * @var string
      */
     public $SummarizeColumnsBy;
+
     /**
      * @Definition Specifies the currency code associated with the report, note that this is one place where this is just the currency code, not a reference to a currency object
      * @xmlType element
@@ -106,6 +113,7 @@ class IPPReportHeader
      * @var string
      */
     public $Currency;
+
     /**
      * @Definition Specifies the customer id (comma separeted) for which the report is run this is just the id, not a reference to a customer object
      * @xmlType element
@@ -115,6 +123,7 @@ class IPPReportHeader
      * @var string
      */
     public $Customer;
+
     /**
      * @Definition Specifies the vendor id (comma separeted) for which the report is run this is just the id, not a reference to a vendor object
      * @xmlType element
@@ -124,6 +133,7 @@ class IPPReportHeader
      * @var string
      */
     public $Vendor;
+
     /**
      * @Definition Specifies the employee id (comma separeted) for which the report is run this is just the id, not a reference to a employee object
      * @xmlType element
@@ -133,6 +143,7 @@ class IPPReportHeader
      * @var string
      */
     public $Employee;
+
     /**
      * @Definition Specifies the product/service id (comma separeted) for which the report is run this is just the id, not a reference to a product/service object
      * @xmlType element
@@ -142,6 +153,7 @@ class IPPReportHeader
      * @var string
      */
     public $Item;
+
     /**
      * @Definition Specifies the class id (comma separeted) for which the report is run this is just the  id, not a reference to a class object
      * @xmlType element
@@ -151,6 +163,7 @@ class IPPReportHeader
      * @var string
      */
     public $Class;
+
     /**
      * @Definition Specifies the Department id (comma separeted) for which the report is run this is just the  id, not a reference to a Department object
      * @xmlType element
@@ -160,6 +173,7 @@ class IPPReportHeader
      * @var string
      */
     public $Department;
+
     /**
      * @Definition Describes the options used for the report
      * @xmlType element
@@ -170,4 +184,6 @@ class IPPReportHeader
      * @var com\intuit\schema\finance\v3\IPPNameValue
      */
     public $Option;
-} // end class IPPReportHeader
+}//end class
+
+ // end class IPPReportHeader

--- a/src/Data/IPPReportPrefs.php
+++ b/src/Data/IPPReportPrefs.php
@@ -20,24 +20,25 @@ class IPPReportPrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPReportPrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPReportPrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPReportPrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPReportPrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product:All
                         report basis
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -48,8 +49,10 @@ class IPPReportPrefs
     /**
      * @Definition
                         Product:QBW
-                        If true, the Aging Reports are based on the transaction date.[br /]
-                        If false, the Aging Reports are based on the due date.
+                        If true, the Aging Reports are based
+                        on the transaction date.[br /]
+                        If false, the Aging Reports are
+                        based on the due date.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPRoundingMethodEnum.php
+++ b/src/Data/IPPRoundingMethodEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPRoundingMethodEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of rounding methods.
+                Description: Enumeration of rounding
+                methods.
 
  */
 class IPPRoundingMethodEnum
@@ -23,22 +24,22 @@ class IPPRoundingMethodEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPRoundingMethodEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPRoundingMethodEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPRoundingMethodEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPRoundingMethodEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPRoundingMethodEnum

--- a/src/Data/IPPRow.php
+++ b/src/Data/IPPRow.php
@@ -12,26 +12,26 @@ class IPPRow
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPRow', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPRow', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPRow', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPRow', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
 
     /**

--- a/src/Data/IPPRowTypeEnum.php
+++ b/src/Data/IPPRowTypeEnum.php
@@ -12,30 +12,30 @@ class IPPRowTypeEnum
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPRowTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPRowTypeEnum', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPRowTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPRowTypeEnum', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPRowTypeEnum

--- a/src/Data/IPPRows.php
+++ b/src/Data/IPPRows.php
@@ -12,26 +12,26 @@ class IPPRows
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPRows', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPRows', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPRows', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPRows', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
 
     /**

--- a/src/Data/IPPSalesFormsPrefs.php
+++ b/src/Data/IPPSalesFormsPrefs.php
@@ -20,20 +20,20 @@ class IPPSalesFormsPrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSalesFormsPrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSalesFormsPrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSalesFormsPrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSalesFormsPrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product:All
@@ -49,6 +49,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBO
                         Defines the CustomField definitions
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -61,6 +62,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBo
                         Custom Transaction Numbers enabled
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -72,6 +74,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBO
                         Enable delayed charges
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -82,7 +85,43 @@ class IPPSalesFormsPrefs
     /**
      * @Definition
                         Product:QBO
+                        Cc Email Address for Sales forms
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName SalesEmailCc
+     * @var com\intuit\schema\finance\v3\IPPEmailAddress
+     */
+    public $SalesEmailCc;
+    /**
+     * @Definition
+                        Product:QBO
+                        Bcc Email Address for Sales forms
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName SalesEmailBcc
+     * @var com\intuit\schema\finance\v3\IPPEmailAddress
+     */
+    public $SalesEmailBcc;
+    /**
+     * @Definition
+                        Product:QBO
+                        Email a Copy to the company for sales form
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName EmailCopyToCompany
+     * @var boolean
+     */
+    public $EmailCopyToCompany;
+    /**
+     * @Definition
+                        Product:QBO
                         Enable Deposit on Invoice
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -112,6 +151,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:All
                         Enable specifying Estimates
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -123,6 +163,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBO
                         Message to customers on estimates only
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -134,6 +175,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBO
                         Specifies ETransaction preference status
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -144,7 +186,9 @@ class IPPSalesFormsPrefs
     /**
      * @Definition
                         Product:QBO
-                        Specifies whether salesForm PDF should be attached with ETransaction emails
+                        Specifies whether salesForm PDF should be attached with
+                        ETransaction emails
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -156,6 +200,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBO
                         Specifies whether online payments is activated
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -166,7 +211,8 @@ class IPPSalesFormsPrefs
     /**
      * @Definition
                         Product:QBO
-                        IPN integration support enable status, this allows emails to include IPN link
+                        IPN integration support enable status, this allows emails to
+                        include IPN link
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -179,6 +225,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBO
                         Specify Invoice Message
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -190,6 +237,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBO
                         Enable specifying Service Dates
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -201,6 +249,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBO
                         Enable specifying Shipping Info
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -212,6 +261,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBO
                         Default shipping account
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -222,7 +272,9 @@ class IPPSalesFormsPrefs
     /**
      * @Definition
                         Product:QBO
-                        Default ItemId Reference type that is selected as part of company setup
+                        Default ItemId Reference type that is selected as part of company
+                        setup
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -234,6 +286,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBO
                         Default Terms
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -242,7 +295,9 @@ class IPPSalesFormsPrefs
      */
     public $DefaultTerms;
     /**
-     * @Definition Product:QBO Default Delivery Method of Invoice and other sales forms - Print, Email are normal options
+     * @Definition Product:QBO Default Delivery Method of Invoice
+                        and other sales forms - Print, Email are normal options
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -278,6 +333,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBW
                         Print Item with Zero amount or not
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -285,23 +341,12 @@ class IPPSalesFormsPrefs
      * @var boolean
      */
     public $PrintItemWithZeroAmount;
-
-    /**
-     * @Definition
-                        Product:QBO
-                        If Email Copy To Company
-     * @xmlType element
-     * @xmlNamespace http://schema.intuit.com/finance/v3
-     * @xmlMinOccurs 0
-     * @xmlName EmailCopyToCompany
-     * @var boolean
-     */
-    public $EmailCopyToCompany;
     /**
      * @Definition
                         Product:QBW
                         Cloud Max Length: 256
-                        [b]QuickBooks Notes[/b][br /]
+                        [b]QuickBooks
+                        Notes[/b][br /]
                         Max Length: 31
 
      * @xmlType element
@@ -314,7 +359,9 @@ class IPPSalesFormsPrefs
     /**
      * @Definition
                         Product:QBW
-                        Default markup rate used to calculate the markup amount on the transactions. To enter a markup rate of 8.5%, enter 8.5, not 0.085.
+                        Default markup rate used to calculate
+                        the markup amount on the transactions. To enter a markup rate of
+                        8.5%, enter 8.5, not 0.085.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -335,6 +382,7 @@ class IPPSalesFormsPrefs
     public $TrackReimbursableExpensesAsIncome;
     /**
      * @Definition QBW: used by QB desktop, not used by QBO
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -344,6 +392,7 @@ class IPPSalesFormsPrefs
     public $UsingSalesOrders;
     /**
      * @Definition QBW: used by QB desktop, not used by QBO
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -353,6 +402,7 @@ class IPPSalesFormsPrefs
     public $UsingPriceLevels;
     /**
      * @Definition QBW: used by QB desktop, not used by QBO
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -364,6 +414,7 @@ class IPPSalesFormsPrefs
      * @Definition
                         Product:QBO
                         Default Customer message
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPSalesItemLineDetail.php
+++ b/src/Data/IPPSalesItemLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPSalesItemLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: SalesItem detail for a transaction line.
+                Description: SalesItem detail for a
+                transaction line.
 
  */
 class IPPSalesItemLineDetail extends IPPItemLineDetail
@@ -23,24 +24,25 @@ class IPPSalesItemLineDetail extends IPPItemLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSalesItemLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSalesItemLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSalesItemLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSalesItemLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL
-                                Description: Date when the service is performed.
+                                Description: Date when the service
+                                is performed.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +54,8 @@ class IPPSalesItemLineDetail extends IPPItemLineDetail
     /**
      * @Definition
                                 Product: QBO
-                                Description: Indicates the total amount of line item including tax.
+                                Description: Indicates the total
+                                amount of line item including tax.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -88,7 +91,8 @@ class IPPSalesItemLineDetail extends IPPItemLineDetail
     /**
      * @Definition
                                 Product: ALL
-                                Description: Internal use only: extension place holder for SalesItemDetail
+                                Description: Internal use only:
+                                extension place holder for SalesItemDetail
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPSalesOrder.php
+++ b/src/Data/IPPSalesOrder.php
@@ -8,9 +8,23 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPSalesOrder
  * @xmlDefinition
                 Product: QBW
-                Description: A sales order is a financial transaction that represents a request received from a customer to purchase products or services. Sales orders help you manage the sale of products and services your customers order. For example, a sales order tracks inventory that is on back order for a customer. Sales Orders are supported only in QuickBooks Premier (desktop) and above. However, if you are accessing a company file created in Premier and above from a lesser edition of QuickBooks (such as Pro), you can do queries against SalesOrders. Using sales orders is optional.
+                Description: A sales order is a
+                financial transaction that represents a request received from a
+                customer to purchase products or services. Sales orders help you
+                manage the sale of products and services your customers order. For
+                example, a sales order tracks inventory that is on back order for a
+                customer. Sales Orders are supported only in QuickBooks Premier
+                (desktop) and above. However, if you are accessing a company file
+                created in Premier and above from a lesser edition of QuickBooks
+                (such as Pro), you can do queries against SalesOrders. Using sales
+                orders is optional.
                 Endpoint: services.intuit.com
-                Business Rules: [li]A sales order must have at least one line that describes the item. [/li][li]A sales order must have a reference to a customer in the [/li][li]If you submit a query with the filter IncludeDiscountLineDetails, the system retrieves either DiscountAmount or DiscountRatePercent with associated values[/li]
+                Business Rules:
+                [li]A sales order must have at least one line that describes the
+                item. [/li][li]A sales order must have a reference to a customer in
+                the [/li][li]If you submit a query with the filter
+                IncludeDiscountLineDetails, the system retrieves either
+                DiscountAmount or DiscountRatePercent with associated values[/li]
 
  */
 class IPPSalesOrder extends IPPSalesTransaction
@@ -25,24 +39,26 @@ class IPPSalesOrder extends IPPSalesTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSalesOrder', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSalesOrder', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSalesOrder', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSalesOrder', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBW
-                                Description: The entire transaction, or individual items are maually closed, i.e. not invoiced.
+                                Description: The entire
+                                transaction, or individual items are maually closed, i.e. not
+                                invoiced.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +68,8 @@ class IPPSalesOrder extends IPPSalesTransaction
      */
     public $ManuallyClosed;
     /**
-     * @Definition Internal use only: extension place holder for SalesOrder
+     * @Definition Internal use only: extension place holder for
+                                SalesOrder
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPSalesOrderItemLineDetail.php
+++ b/src/Data/IPPSalesOrderItemLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPSalesOrderItemLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: SalesOrder item detail for a transaction line.
+                Description: SalesOrder item detail for
+                a transaction line.
 
  */
 class IPPSalesOrderItemLineDetail extends IPPSalesItemLineDetail
@@ -23,24 +24,26 @@ class IPPSalesOrderItemLineDetail extends IPPSalesItemLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSalesOrderItemLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSalesOrderItemLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSalesOrderItemLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSalesOrderItemLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL
-                                Description: The item on the line is marked as if fully received, but it is closed as no longer available.
+                                Description: The item on the line
+                                is marked as if fully received, but it is closed as no longer
+                                available.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPSalesReceipt.php
+++ b/src/Data/IPPSalesReceipt.php
@@ -20,20 +20,20 @@ class IPPSalesReceipt extends IPPSalesTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSalesReceipt', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSalesReceipt', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSalesReceipt', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSalesReceipt', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition Extension entity for SalesReceipt
 

--- a/src/Data/IPPSalesRep.php
+++ b/src/Data/IPPSalesRep.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPSalesRep
  * @xmlDefinition
                                 Product: QBW
-                                Description:  [br/] One of the 3 references is Required for the create operation.
+                                Description: [br/] One of the 3
+                                references is Required for the create operation.
 
  */
 class IPPSalesRep extends IPPIntuitEntity
@@ -23,24 +24,27 @@ class IPPSalesRep extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSalesRep', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSalesRep', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSalesRep', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSalesRep', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBW
-                                Description: The SalesRep type. Also, one of the three entity references (either the Name or the ID of the Employee, OtherName, or Vendor) is required for the Create request.[br /]
+                                Description: The SalesRep type.
+                                Also, one of the three entity references (either the Name or the
+                                ID of the Employee, OtherName, or Vendor) is required for the
+                                Create request.[br /]
                                 Required: QBW
 
      * @xmlType element
@@ -53,7 +57,9 @@ class IPPSalesRep extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: True if active. Inactive sales reps may be hidden from display and may not be used on financial transactions.
+                                Description: True if active.
+                                Inactive sales reps may be hidden from display and may not be
+                                used on financial transactions.
                                 Filterable: QBW
 
      * @xmlType element
@@ -66,7 +72,10 @@ class IPPSalesRep extends IPPIntuitEntity
     /**
      * @Definition
                                     Product: QBW
-                                    Description: Reference to the Employee, if that is the SalesRep type. One of the three entity references (either the Name or the ID of the Employee, OtherName, or Vendor) is required for the Create request.
+                                    Description: Reference to the
+                                    Employee, if that is the SalesRep type. One of the three entity
+                                    references (either the Name or the ID of the Employee,
+                                    OtherName, or Vendor) is required for the Create request.
                                     Required: QBW
 
      * @xmlType element
@@ -79,7 +88,10 @@ class IPPSalesRep extends IPPIntuitEntity
     /**
      * @Definition
                                     Product: QBW
-                                    Description: Reference to the Vendor, if that is the SalesRep type. One of the three entity references (either the Name or the ID of the Employee, OtherName, or Vendor) is required for the Create request.
+                                    Description: Reference to the
+                                    Vendor, if that is the SalesRep type. One of the three entity
+                                    references (either the Name or the ID of the Employee,
+                                    OtherName, or Vendor) is required for the Create request.
                                     Required: QBW
 
      * @xmlType element
@@ -92,7 +104,10 @@ class IPPSalesRep extends IPPIntuitEntity
     /**
      * @Definition
                                     Product: QBW
-                                    Description: Reference to the OtherName, if that is the SalesRep type. One of the three entity references (either the Name or the ID of the Employee, OtherName, or Vendor) is required for the Create request.
+                                    Description: Reference to the
+                                    OtherName, if that is the SalesRep type. One of the three
+                                    entity references (either the Name or the ID of the Employee,
+                                    OtherName, or Vendor) is required for the Create request.
                                     Required: QBW
 
      * @xmlType element
@@ -105,7 +120,9 @@ class IPPSalesRep extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: User recognizable initials of the Sales Rep.[br/]Required for the Create request.[br/] Max Length: 5 characters.
+                                Description: User recognizable
+                                initials of the Sales Rep.[br/]Required for the Create
+                                request.[br/] Max Length: 5 characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -117,7 +134,8 @@ class IPPSalesRep extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: Internal use only: extension place holder for SalesRep
+                                Description: Internal use only:
+                                extension place holder for SalesRep
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPSalesRepTypeEnum.php
+++ b/src/Data/IPPSalesRepTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPSalesRepTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of sales rep types.
+                Description: Enumeration of sales rep
+                types.
 
  */
 class IPPSalesRepTypeEnum
@@ -23,22 +24,22 @@ class IPPSalesRepTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSalesRepTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSalesRepTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSalesRepTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSalesRepTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPSalesRepTypeEnum

--- a/src/Data/IPPSalesTermTypeEnum.php
+++ b/src/Data/IPPSalesTermTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPSalesTermTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of sales term types.
+                Description: Enumeration of sales term
+                types.
 
  */
 class IPPSalesTermTypeEnum
@@ -23,22 +24,22 @@ class IPPSalesTermTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSalesTermTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSalesTermTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSalesTermTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSalesTermTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPSalesTermTypeEnum

--- a/src/Data/IPPSalesTransaction.php
+++ b/src/Data/IPPSalesTransaction.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPSalesTransaction
  * @xmlDefinition
                 Product: ALL
-                Description: Base class of all Sales transaction entities.
+                Description: Base class of all Sales
+                transaction entities.
 
  */
 class IPPSalesTransaction extends IPPTransaction
@@ -23,24 +24,26 @@ class IPPSalesTransaction extends IPPTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSalesTransaction', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSalesTransaction', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSalesTransaction', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSalesTransaction', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBO
-                                Description: If AutoDocNumber is true, DocNumber is generated automatically.  If false or null, the DocNumber is generated based on preference of the user.
+                                Description: If AutoDocNumber is true, DocNumber is generated automatically.
+                                If false or null, the DocNumber is generated based on preference
+                                of the user.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -55,7 +58,8 @@ class IPPSalesTransaction extends IPPTransaction
                                 Description: Reference to a Customer or job.
                                 Filterable: QBW
                                 InputType: ReadWrite
-                                BusinessRules: QBW: CustomerRef is mandatory for some SalesTransactions like Invoice
+                                BusinessRules: QBW: CustomerRef is mandatory for some SalesTransactions like
+                                Invoice
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -67,8 +71,17 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: QBO: For an Invoice, this is the user-entered message to the customer that does appear in the invoice, and does appear in the printed invoice. The maximum length for Invoice Msg is 1000 characters.[br /]For a Bill, this is the memo of the transaction to provide more detail, and does not appear in the printed message of the bill. The maximum length for Bill Msg is 4000 characters.[br /]For a CreditCardCharge, this message appears in the printed record; maximum length is 4000 characters.[br /]Not supported for BillPayment, JournalEntry or Payment.
-                                Description: QBW: User-entered message to the customer; this message will be visible to end user on their transactions.
+                                Description: QBO: For an Invoice, this is the user-entered message to the
+                                customer that does appear in the invoice, and does appear in the
+                                printed invoice. The maximum length for Invoice Msg is 1000
+                                characters.[br /]For a Bill, this is the memo of the transaction
+                                to provide more detail, and does not appear in the printed
+                                message of the bill. The maximum length for Bill Msg is 4000
+                                characters.[br /]For a CreditCardCharge, this message appears in
+                                the printed record; maximum length is 4000 characters.[br /]Not
+                                supported for BillPayment, JournalEntry or Payment.
+                                Description: QBW: User-entered message to the customer; this message will be
+                                visible to end user on their transactions.
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -81,8 +94,12 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: QBO: Bill-to address of the Invoice.[br]See [a href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01000_Using_Data_Service_Entities#Addresses"]Addresses[/a]
-                                Description: QBW: The physical (postal) address where the bill or invoice is sent.[br]See [a href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01000_Using_Data_Service_Entities#Addresses"]Addresses[/a]
+                                Description: QBO: Bill-to address
+                                of the Invoice.[br]See [a
+                                href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01000_Using_Data_Service_Entities#Addresses"]Addresses[/a]
+                                Description: QBW: The physical (postal) address where the bill
+                                or invoice is sent.[br]See [a
+                                href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01000_Using_Data_Service_Entities#Addresses"]Addresses[/a]
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -95,8 +112,15 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: QBO: Shipping address of the Invoice.[br]See [a href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01000_Using_Data_Service_Entities#Addresses"]Addresses[/a]
-                                Description: QBW: Identifies the address where the goods must be shipped. [br /]QuickBooks Note: If ShipAddr is not specified, and a default ship-to address is specified in QuickBooks for this customer, the default ship-to address will be used by QuickBooks.[br]See [a href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01000_Using_Data_Service_Entities#Addresses"]Addresses[/a]
+                                Description: QBO: Shipping address
+                                of the Invoice.[br]See [a
+                                href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01000_Using_Data_Service_Entities#Addresses"]Addresses[/a]
+                                Description: QBW: Identifies the address where the goods must be
+                                shipped. [br /]QuickBooks Note: If ShipAddr is not specified,
+                                and a default ship-to address is specified in QuickBooks for
+                                this customer, the default ship-to address will be used by
+                                QuickBooks.[br]See [a
+                                href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01000_Using_Data_Service_Entities#Addresses"]Addresses[/a]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -107,8 +131,22 @@ class IPPSalesTransaction extends IPPTransaction
     public $ShipAddr;
     /**
      * @Definition
+                                                                Product: QBO
+                                                                Description: Specifies whether
+                                                                shipping address is in free-form or structured-form (city/state etc.)
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName FreeFormAddress
+     * @var boolean
+     */
+    public $FreeFormAddress;
+    /**
+     * @Definition
                                 Product: QBW
-                                Description: Reference to the party receiving payment.
+                                Description: Reference to the party
+                                receiving payment.
                                 InputType: ReadOnly
 
      * @xmlType element
@@ -121,7 +159,8 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBW
-                                Description: Reference to the Class associated with the transaction.
+                                Description: Reference to the Class
+                                associated with the transaction.
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -134,7 +173,8 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBW
-                                Description: Reference to the SalesTerm associated with the transaction.
+                                Description: Reference to the
+                                SalesTerm associated with the transaction.
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -146,8 +186,13 @@ class IPPSalesTransaction extends IPPTransaction
     public $SalesTermRef;
     /**
      * @br
-     * @ul If DueDate is not included when creating an invoice, QuickBooks may determine the due date according to the terms set for this customer.
-                                               If the Terms are not provided, the Due Date is set to the transaction date.
+     * @ul
+                                    If DueDate is not included when creating an invoice,
+                                        QuickBooks may determine the due date according to the terms
+                                        set for this customer.
+                                    If the Terms are not provided, the Due Date is set to the
+                                        transaction date.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -158,7 +203,8 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBW
-                                Description: Reference to the SalesRep associated with the transaction.
+                                Description: Reference to the
+                                SalesRep associated with the transaction.
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -185,8 +231,13 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: "Free On Board", the terms between buyer and seller regarding transportation costs; does not have any bookkeeping implications.
-                                Description: "Free On Board", the terms between buyer and seller regarding transportation costs; does not have any bookkeeping implications.
+                                Description: "Free On Board", the
+                                terms between buyer and seller regarding transportation costs;
+                                does not have any bookkeeping implications.
+                                Description: "Free On
+                                Board", the terms between buyer and seller regarding
+                                transportation costs; does not have any bookkeeping
+                                implications.
                                 ValidRange: QBW: max=13
                                 ValidRange: QBO: max=15
 
@@ -213,7 +264,8 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBW
-                                Description: Date for delivery of goods or services.
+                                Description: Date for delivery of
+                                goods or services.
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -226,7 +278,9 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBW
-                                Description: Shipping provider's tracking number for the delivery of the goods associated with the transaction.
+                                Description: Shipping provider's
+                                tracking number for the delivery of the goods associated with
+                                the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -238,7 +292,9 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Indicates the GlobalTax model if the model inclusive of tax, exclusive of taxes or not applicable
+                                Description: Indicates the
+                                GlobalTax model if the model inclusive of tax, exclusive of
+                                taxes or not applicable
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -250,8 +306,14 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: All
-                                Description: QBO: Indicates the total amount of the transaction. This includes the total of all the charges, allowances and taxes. By default, this is recalculated based on sub items total and overridden.
-                                Description: QBW: Indicates the total amount of the transaction. This includes the total of all the charges, allowances and taxes.[br /]Calculated by QuickBooks business logic; cannot be written to QuickBooks.
+                                Description: QBO: Indicates the
+                                total amount of the transaction. This includes the total of all
+                                the charges, allowances and taxes. By default, this is
+                                recalculated based on sub items total and overridden.
+                                Description: QBW: Indicates the total amount of the transaction.
+                                This includes the total of all the charges, allowances and
+                                taxes.[br /]Calculated by QuickBooks business logic; cannot be
+                                written to QuickBooks.
                                 Filterable: QBW
                                 Sortable: QBW
                                 InputType: QBW: OverrideOnSync
@@ -266,7 +328,12 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: QBW: Total amount of the transaction in the home currency for multi-currency enabled companies. Single currency companies will not have this field. Includes the total of all the charges, allowances and taxes. Calculated by QuickBooks business logic. Cannot be written to QuickBooks.
+                                Description: QBW: Total amount of
+                                the transaction in the home currency for multi-currency enabled
+                                companies. Single currency companies will not have this field.
+                                Includes the total of all the charges, allowances and taxes.
+                                Calculated by QuickBooks business logic. Cannot be written to
+                                QuickBooks.
                                 InputType: QBW: ReadOnly
 
      * @xmlType element
@@ -279,7 +346,10 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: If false or null, calculate the sales tax first, and then apply the discount. If true, subtract the discount first and then calculate the sales tax.
+                                Description: If false or null,
+                                calculate the sales tax first, and then apply the discount. If
+                                true, subtract the discount first and then calculate the sales
+                                tax.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -291,7 +361,8 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBW
-                                Description: Reference to the Template for the invoice form.
+                                Description: Reference to the
+                                Template for the invoice form.
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -304,7 +375,8 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: Printing status of the invoice.[br /]
+                                Description: Printing status of the
+                                invoice.[br /]
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -317,7 +389,8 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: Email status of the invoice.[br /]
+                                Description: Email status of the
+                                invoice.[br /]
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -330,9 +403,20 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Identifies the e-mail address where the invoice is sent. At present, you can provide only one e-mail address.[br /]If the ToBeEmailed attribute is true and the BillEmail attribute contains an e-mail address, the user can send an e-mail message to the e-mail address that is specified in the BillEmail attribute.[br /]If the BillEmail attribute contains an invalid e-mail address, QBO does not send the e-mail message to the invalid e-mail address. QBO also does not return any error message to indicate that the e-mail address is invalid.[br /]The maximum length for BillEmail is 100 characters.
+                                Description: Identifies the e-mail
+                                address where the invoice is sent. At present, you can provide
+                                only one e-mail address.[br /]If the ToBeEmailed attribute is
+                                true and the BillEmail attribute contains an e-mail address, the
+                                user can send an e-mail message to the e-mail address that is
+                                specified in the BillEmail attribute.[br /]If the BillEmail
+                                attribute contains an invalid e-mail address, QBO does not send
+                                the e-mail message to the invalid e-mail address. QBO also does
+                                not return any error message to indicate that the e-mail address
+                                is invalid.[br /]The maximum length for BillEmail is 100
+                                characters.
                                 Product: QBW
-                                Description: Identifies the email address where the bill or invoice is sent. [br /]UNSUPPORTED FIELD.
+                                Description: Identifies the email address
+                                where the bill or invoice is sent. [br /]UNSUPPORTED FIELD.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -341,13 +425,22 @@ class IPPSalesTransaction extends IPPTransaction
      * @var com\intuit\schema\finance\v3\IPPEmailAddress
      */
     public $BillEmail;
-
     /**
      * @Definition
                                 Product: QBO
-                                Description: Identifies the e-mail address where the invoice is sent. At present, you can provide only one e-mail address.[br /]If the ToBeEmailed attribute is true and the BillEmail attribute contains an e-mail address, the user can send an e-mail message to the e-mail address that is specified in the BillEmail attribute.[br /]If the BillEmail attribute contains an invalid e-mail address, QBO does not send the e-mail message to the invalid e-mail address. QBO also does not return any error message to indicate that the e-mail address is invalid.[br /]The maximum length for BillEmail is 100 characters.
+                                Description: Identifies the cc
+                                e-mail address where the invoice is sent. If the ToBeEmailed
+                                attribute is true and the BillEmailCc attribute contains an
+                                e-mail address, the user can send an e-mail message to the
+                                e-mail address that is specified in the BillEmailCc
+                                attribute.[br /] If the BillEmailCc attribute contains an
+                                invalid e-mail address, QBO does not send the e-mail message to
+                                the invalid cc e-mail address. [br /]The maximum length for
+                                BillEmailCc is 200 characters.
                                 Product: QBW
-                                Description: Identifies the email address where the bill or invoice is sent. Available in Version 8
+                                Description:
+                                Identifies the cc email address where the bill or invoice is
+                                sent. [br /]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -356,13 +449,22 @@ class IPPSalesTransaction extends IPPTransaction
      * @var com\intuit\schema\finance\v3\IPPEmailAddress
      */
     public $BillEmailCc;
-
     /**
      * @Definition
                                 Product: QBO
-                                Description: Identifies the e-mail address where the invoice is sent. At present, you can provide only one e-mail address.[br /]If the ToBeEmailed attribute is true and the BillEmail attribute contains an e-mail address, the user can send an e-mail message to the e-mail address that is specified in the BillEmail attribute.[br /]If the BillEmail attribute contains an invalid e-mail address, QBO does not send the e-mail message to the invalid e-mail address. QBO also does not return any error message to indicate that the e-mail address is invalid.[br /]The maximum length for BillEmail is 100 characters.
+                                Description: Identifies the bcc
+                                e-mail address where the invoice is sent. If the ToBeEmailed
+                                attribute is true and the BillEmailBcc attribute contains an
+                                e-mail address, the user can send an e-mail message to the
+                                e-mail address that is specified in the BillEmailBcc
+                                attribute.[br /] If the BillEmailCc attribute contains an
+                                invalid bcc e-mail address, QBO does not send the e-mail message
+                                to the invalid bcc e-mail address. [br /]The maximum length for
+                                BillEmailBcc is 200 characters.
                                 Product: QBW
-                                Description: Identifies the email address where the bill or invoice is sent. Available on Minor Version 8.
+                                Description:
+                                Identifies the bcc email address where the bill or invoice is
+                                sent as bcc. [br /]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -374,7 +476,9 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBW
-                                Description: Reference to the ARAccount (accounts receivable account) associated with the transaction.
+                                Description: Reference to the
+                                ARAccount (accounts receivable account) associated with the
+                                transaction.
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -387,9 +491,12 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: The balance reflecting any payments made against the transaction. Initially this will be equal to the TotalAmt.
+                                Description: The balance reflecting
+                                any payments made against the transaction. Initially this will
+                                be equal to the TotalAmt.
                                 Product: QBW
-                                Description: Indicates the unpaid amount of the transaction.
+                                Description: Indicates the
+                                unpaid amount of the transaction.
                                 Filterable: ALL
                                 Sortable: QBW
                                 InputType: ReadOnly
@@ -404,9 +511,14 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: The balance reflecting any payments made against the transaction in home currency. Initially this will be equal to the HomeTotalAmt.[br /]Read-only field.
+                                Description: The balance reflecting
+                                any payments made against the transaction in home currency.
+                                Initially this will be equal to the HomeTotalAmt.[br /]Read-only
+                                field.
                                 Product: QBW
-                                Description: Indicates the unpaid amount of the transaction in home currency.[br /]Cannot be written to QuickBooks.
+                                Description: Indicates the unpaid amount of
+                                the transaction in home currency.[br /]Cannot be written to
+                                QuickBooks.
                                 Filterable: ALL
                                 Sortable: QBW
 
@@ -420,7 +532,8 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: Indicates whether the transaction is a finance charge.
+                                Description: Indicates whether the
+                                transaction is a finance charge.
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -433,7 +546,8 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the PaymentMethod.
+                                Description: Reference to the
+                                PaymentMethod.
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -446,7 +560,10 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: The reference number for the payment received (I.e. Check # for a check, envelope # for a cash donation, CreditCardTransactionID for a credit card payment)
+                                Description: The reference number
+                                for the payment received (I.e. Check # for a check, envelope #
+                                for a cash donation, CreditCardTransactionID for a credit card
+                                payment)
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -458,7 +575,9 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Valid values are Cash, Check, CreditCard, or Other. No defaults. Cash based expense is not supported by QuickBooks Windows.
+                                Description: Valid values are Cash, Check, CreditCard, or
+                                Other. No defaults. Cash based expense is not supported by
+                                QuickBooks Windows.
                                 NotApplicableTo: Estimate, SalesOrder
 
      * @xmlType element
@@ -471,7 +590,8 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                     Product: ALL
-                                    Description Information about a check payment for the Invoice.
+                                    Description Information about a check payment for the
+                                    Invoice.
                                     NotApplicableTo: Estimate, SalesOrder
 
      * @xmlType element
@@ -484,7 +604,8 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                     Product: ALL
-                                    Description Information about a credit card payment for the Invoice.
+                                    Description Information about a credit card payment for the
+                                    Invoice.
                                     NotApplicableTo: Estimate, SalesOrder
 
      * @xmlType element
@@ -497,8 +618,12 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: ALL
-                                Description: QBW: Reference to the DepositToAccount entity. If not specified, the Undeposited Funds account will be used.
-                                Description: QBO: Asset account where the payment money is deposited. If you do not specify this account, QBO uses the Undeposited Funds account. Supported for Payment and SalesReceipt only.
+                                Description: QBW: Reference to the
+                                DepositToAccount entity. If not specified, the Undeposited Funds
+                                account will be used.
+                                Description: QBO: Asset account where the payment money is deposited. If you
+                                do not specify this account, QBO uses the Undeposited Funds
+                                account. Supported for Payment and SalesReceipt only.
                                 NotApplicableTo: QBW: Estimate, SalesOrder
 
      * @xmlType element
@@ -523,7 +648,9 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Indicates the discount rate that is applied on the transaction as a whole. This will be pro-rated through item lines for tax calculation.
+                                Description: Indicates the discount
+                                rate that is applied on the transaction as a whole. This will be
+                                pro-rated through item lines for tax calculation.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -535,7 +662,9 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: Indicates the discount amount that is applied on the transaction as a whole. This will be pro-rated through item lines for tax calculation.
+                                Description: Indicates the discount
+                                amount that is applied on the transaction as a whole. This will
+                                be pro-rated through item lines for tax calculation.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -547,8 +676,10 @@ class IPPSalesTransaction extends IPPTransaction
     /**
      * @Definition
                                 Product: QBO
-                                Description: this is the reference to the NotaFiscal created for the salesTransaction.
-                                ValidRange: QBO: max=30
+                                Description: this is the reference
+                                to the NotaFiscal created for the salesTransaction.
+                                ValidRange:
+                                QBO: max=30
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -557,4 +688,17 @@ class IPPSalesTransaction extends IPPTransaction
      * @var string
      */
     public $GovtTxnRefIdentifier;
+    /**
+     * @Definition
+                                Product: ALL
+                                Description: Reference to the
+                                TaxExemptionId and TaxExemptionReason for this customer.
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName TaxExemptionRef
+     * @var com\intuit\schema\finance\v3\IPPReferenceType
+     */
+    public $TaxExemptionRef;
 } // end class IPPSalesTransaction

--- a/src/Data/IPPServiceTypeEnum.php
+++ b/src/Data/IPPServiceTypeEnum.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType string
  * @xmlName IPPServiceTypeEnum
  * @var IPPServiceTypeEnum
- * @xmlDefinition Enumeration of item service type for India sales tax
+ * @xmlDefinition Enumeration of item service type for India sales
+                tax
  */
 class IPPServiceTypeEnum
 {
@@ -20,22 +21,22 @@ class IPPServiceTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPServiceTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPServiceTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPServiceTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPServiceTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPServiceTypeEnum

--- a/src/Data/IPPShipMethod.php
+++ b/src/Data/IPPShipMethod.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPShipMethod
  * @xmlDefinition
                 Product: ALL
-                Description:  Describes a method of shipping for the company
+                Description: Describes a method of
+                shipping for the company
 
  */
 class IPPShipMethod extends IPPIntuitEntity
@@ -23,24 +24,25 @@ class IPPShipMethod extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPShipMethod', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPShipMethod', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPShipMethod', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPShipMethod', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL
-                                Description: The name of the shipping method (i.e. FedEx 2-day)
+                                Description: The name of the
+                                shipping method (i.e. FedEx 2-day)
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +54,8 @@ class IPPShipMethod extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: Indication of whether or not this shipping method is still used by the company.
+                                Description: Indication of whether
+                                or not this shipping method is still used by the company.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -61,7 +64,8 @@ class IPPShipMethod extends IPPIntuitEntity
      */
     public $Active;
     /**
-     * @Definition Internal use only: extension place holder for ShipMethod
+     * @Definition Internal use only: extension place holder for
+                                ShipMethod
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPSpecialItemTypeEnum.php
+++ b/src/Data/IPPSpecialItemTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPSpecialItemTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of special item types.
+                Description: Enumeration of special
+                item types.
 
  */
 class IPPSpecialItemTypeEnum
@@ -23,22 +24,22 @@ class IPPSpecialItemTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSpecialItemTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSpecialItemTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSpecialItemTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSpecialItemTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPSpecialItemTypeEnum

--- a/src/Data/IPPSpecialTaxTypeEnum.php
+++ b/src/Data/IPPSpecialTaxTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPSpecialTaxTypeEnum
  * @xmlDefinition
                 Product: QBO
-                Description: Enumeration of SpecialTaxType
+                Description: Enumeration of
+                SpecialTaxType
 
  */
 class IPPSpecialTaxTypeEnum
@@ -23,22 +24,22 @@ class IPPSpecialTaxTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSpecialTaxTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSpecialTaxTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSpecialTaxTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSpecialTaxTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPSpecialTaxTypeEnum

--- a/src/Data/IPPStatementCharge.php
+++ b/src/Data/IPPStatementCharge.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType Transaction
  * @xmlName IPPStatementCharge
  * @var IPPStatementCharge
- * @xmlDefinition Financial transaction representing a request for payment for goods or services that have been sold.
+ * @xmlDefinition Financial transaction representing a request for
+                payment for goods or services that have been sold.
+
  */
 class IPPStatementCharge extends IPPTransaction
 {
@@ -20,22 +22,23 @@ class IPPStatementCharge extends IPPTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPStatementCharge', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPStatementCharge', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPStatementCharge', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPStatementCharge', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition If Credit is Null or False, it is considered as Charge. If true, the StatementCharge represents a Refund
+     * @Definition If Credit is Null or False, it is considered as
+                                Charge. If true, the StatementCharge represents a Refund
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -55,8 +58,10 @@ class IPPStatementCharge extends IPPTransaction
      */
     public $CustomerRef;
     /**
-     * @Definition Identifies the party or location that the payment is to be remitted to or sent to.
-                                [b]QuickBooks Notes[/b][br /]
+     * @Definition Identifies the party or location that the
+                                payment is to be remitted to or sent to.
+                                [b]QuickBooks
+                                Notes[/b][br /]
                                 Non QB-writable.
 
      * @xmlType element
@@ -67,9 +72,13 @@ class IPPStatementCharge extends IPPTransaction
      */
     public $RemitToRef;
     /**
-     * @Definition ARAccountReferenceGroup Identifies the AR Account to be used for this Credit Memo.
-                                [b]QuickBooks Notes[/b][br /]
-                                The AR Account should always be specified or a default will be used.
+     * @Definition ARAccountReferenceGroup Identifies the AR
+                                Account to be used for this Credit Memo.
+                                [b]QuickBooks
+                                Notes[/b][br /]
+                                The AR Account should always be specified or a
+                                default will be used.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -87,6 +96,7 @@ class IPPStatementCharge extends IPPTransaction
     public $ClassRef;
     /**
      * @Definition Date when the Charge is to be paid.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -96,6 +106,7 @@ class IPPStatementCharge extends IPPTransaction
     public $DueDate;
     /**
      * @Definition Date when the customer Statement was created
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -104,9 +115,12 @@ class IPPStatementCharge extends IPPTransaction
      */
     public $BilledDate;
     /**
-     * @Definition Indicates the total amount of the entity associated. This includes the total of all the charges, allowances and taxes.
+     * @Definition Indicates the total amount of the entity
+                                associated. This includes the total of all the charges,
+                                allowances and taxes.
                                 [b]QuickBooks Notes[/b][br /]
-                                Non QB-writable.
+                                Non
+                                QB-writable.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -116,7 +130,8 @@ class IPPStatementCharge extends IPPTransaction
      */
     public $TotalAmt;
     /**
-     * @Definition Internal use only: extension place holder for StatementCharge
+     * @Definition Internal use only: extension place holder for
+                                StatementCharge
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPStatus.php
+++ b/src/Data/IPPStatus.php
@@ -9,33 +9,32 @@ namespace QuickBooksOnline\API\Data;
  * @xmlDefinition
                 Product: QBW
                 Description: generic meta data response for any add mod
-
  */
 class IPPStatus extends IPPIntuitEntity
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPStatus', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPStatus', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPStatus', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPStatus', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition
@@ -50,6 +49,7 @@ class IPPStatus extends IPPIntuitEntity
      * @var string
      */
     public $RequestId;
+
     /**
      * @Definition
                             Product: QBW
@@ -63,6 +63,7 @@ class IPPStatus extends IPPIntuitEntity
      * @var string
      */
     public $BatchId;
+
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -70,6 +71,7 @@ class IPPStatus extends IPPIntuitEntity
      * @var string
      */
     public $ObjectType;
+
     /**
      * @Definition
                             Product: QBW
@@ -83,6 +85,7 @@ class IPPStatus extends IPPIntuitEntity
      * @var string
      */
     public $StateCode;
+
     /**
      * @Definition
                             Product: QBW
@@ -95,6 +98,7 @@ class IPPStatus extends IPPIntuitEntity
      * @var string
      */
     public $StateDesc;
+
     /**
      * @Definition
                             Product: QBW
@@ -107,6 +111,7 @@ class IPPStatus extends IPPIntuitEntity
      * @var string
      */
     public $MessageCode;
+
     /**
      * @Definition
                         Product: QBW
@@ -119,4 +124,6 @@ class IPPStatus extends IPPIntuitEntity
      * @var string
      */
     public $MessageDesc;
-} // end class IPPStatus
+}//end class
+
+ // end class IPPStatus

--- a/src/Data/IPPStatusInfo.php
+++ b/src/Data/IPPStatusInfo.php
@@ -4,12 +4,14 @@ namespace QuickBooksOnline\API\Data;
 /**
  * @xmlNamespace http://schema.intuit.com/finance/v3
  * @xmlType
- * @xmlName IPPCheckPurchase
- * @var IPPCheckPurchase
- * @xmlDefinition Financial Transaction information that pertains to
-                the entire Check.
+ * @xmlName IPPStatusInfo
+ * @var IPPStatusInfo
+ * @xmlDefinition
+                Product: QBO
+                Description: Log of Statuses for Transactions. Currently is used for Invoice. Can be extended to others.
+
  */
-class IPPCheckPurchase
+class IPPStatusInfo
 {
 
         /**
@@ -24,7 +26,7 @@ class IPPCheckPurchase
     public function __construct($keyValInitializers = array(), $verbose = false)
     {
         foreach ($keyValInitializers as $initPropName => $initPropVal) {
-            if (property_exists('IPPCheckPurchase', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPCheckPurchase', $initPropName)) {
+            if (property_exists('IPPStatusInfo', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPStatusInfo', $initPropName)) {
                 $this->{$initPropName} = $initPropVal;
             } else {
                 if ($verbose) {
@@ -36,44 +38,39 @@ class IPPCheckPurchase
 
     
     /**
-     * @xmlType element
-     * @xmlNamespace http://schema.intuit.com/finance/v3
-     * @xmlMinOccurs 0
-     * @xmlName AccountRef
-     * @var com\intuit\schema\finance\v3\IPPReferenceType
-     */
-    public $AccountRef;
-    /**
-     * @Definition Address to which the payment should be sent.
+     * @Definition
+                        Product: QBO
+                        Description: Holds status information
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
-     * @xmlName PayeeAddr
-     * @var com\intuit\schema\finance\v3\IPPPhysicalAddress
-     */
-    public $PayeeAddr;
-    /**
-     * @Definition In case of check expense, MemoOnCheck represent
-                        the data written on the check as message written to the Payee to
-                        physically read on the check
-
-     * @xmlType element
-     * @xmlNamespace http://schema.intuit.com/finance/v3
-     * @xmlMinOccurs 0
-     * @xmlName MemoOnCheck
+     * @xmlName status
      * @var string
      */
-    public $MemoOnCheck;
+    public $status;
     /**
-     * @Definition ReadToPrint is a flag indicating if the Check is
-                        ready for printing
+     * @Definition
+                        Product: QBO
+                        Description: Holds the status update date.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
-     * @xmlName PrintStatus
-     * @var com\intuit\schema\finance\v3\IPPPrintStatusEnum
+     * @xmlName statusDate
+     * @var string
      */
-    public $PrintStatus;
-} // end class IPPCheckPurchase
+    public $statusDate;
+    /**
+     * @Definition
+                        Product: QBO
+                        Description: call to action for this status
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName callToAction
+     * @var string
+     */
+    public $callToAction;
+} // end class IPPStatusInfo

--- a/src/Data/IPPStringTypeCustomFieldDefinition.php
+++ b/src/Data/IPPStringTypeCustomFieldDefinition.php
@@ -23,20 +23,20 @@ class IPPStringTypeCustomFieldDefinition extends IPPCustomFieldDefinition
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPStringTypeCustomFieldDefinition', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPStringTypeCustomFieldDefinition', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPStringTypeCustomFieldDefinition', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPStringTypeCustomFieldDefinition', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL

--- a/src/Data/IPPSubTotalLineDetail.php
+++ b/src/Data/IPPSubTotalLineDetail.php
@@ -7,8 +7,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPSubTotalLineDetail
  * @var IPPSubTotalLineDetail
  * @xmlDefinition
-Product: ALL
-Description: SubTotalLine detail for a transaction line.
+                Product: ALL
+                Description: SubTotalLine detail for a transaction line.
 
  */
 class IPPSubTotalLineDetail
@@ -23,24 +23,27 @@ class IPPSubTotalLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSubTotalLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSubTotalLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSubTotalLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSubTotalLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL
-                        Description: Reference to the Item. When a line lacks an ItemRef it will be treated as "documentation" and the Amount will be ignored.
+                        Description: Reference to the Item.
+                        When a line lacks an ItemRef it will be treated as "documentation"
+                        and the Amount will be ignored.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -51,7 +54,8 @@ class IPPSubTotalLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Date when the service is performed.
+                        Description: Date when the service is
+                        performed.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPSummarizeColumnsByEnum.php
+++ b/src/Data/IPPSummarizeColumnsByEnum.php
@@ -10,31 +10,35 @@ namespace QuickBooksOnline\API\Data;
 class IPPSummarizeColumnsByEnum
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSummarizeColumnsByEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSummarizeColumnsByEnum', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSummarizeColumnsByEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSummarizeColumnsByEnum', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
+    }//end __construct()
+
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
-} // end class IPPSummarizeColumnsByEnum
+    public $value;
+}//end class
+
+ // end class IPPSummarizeColumnsByEnum

--- a/src/Data/IPPSummary.php
+++ b/src/Data/IPPSummary.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPSummary
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSummary', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSummary', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSummary', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSummary', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @xmlType element
@@ -42,4 +42,6 @@ class IPPSummary
      * @var com\intuit\schema\finance\v3\IPPColData
      */
     public $ColData;
-} // end class IPPSummary
+}//end class
+
+ // end class IPPSummary

--- a/src/Data/IPPSymbolPositionEnum.php
+++ b/src/Data/IPPSymbolPositionEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPSymbolPositionEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of symbol positions.
+                Description: Enumeration of symbol
+                positions.
 
  */
 class IPPSymbolPositionEnum
@@ -23,22 +24,22 @@ class IPPSymbolPositionEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSymbolPositionEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSymbolPositionEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSymbolPositionEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSymbolPositionEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPSymbolPositionEnum

--- a/src/Data/IPPSyncActivity.php
+++ b/src/Data/IPPSyncActivity.php
@@ -7,35 +7,34 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPSyncActivity
  * @var IPPSyncActivity
  * @xmlDefinition
-       			 Product: QBW
-        		 Description: Provides upload/writeback activity for a given period of time. Query activity using
-        		 			  StartSyncTMS OR EndSyncTMS
-
+                    Product: QBW
+                 Description: Provides upload/writeback activity for a given period of time. Query activity using
+                               StartSyncTMS OR EndSyncTMS
  */
 class IPPSyncActivity extends IPPIntuitEntity
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSyncActivity', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSyncActivity', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSyncActivity', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSyncActivity', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
 
     /**

--- a/src/Data/IPPSyncError.php
+++ b/src/Data/IPPSyncError.php
@@ -11,32 +11,31 @@ namespace QuickBooksOnline\API\Data;
                 Description: Wrapper object for specifying both version of the objects
                 If there is any warnings on a object basis that is also send back
                 This object is output object only
-
  */
 class IPPSyncError
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSyncError', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSyncError', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSyncError', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSyncError', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
 
     /**

--- a/src/Data/IPPSyncErrorResponse.php
+++ b/src/Data/IPPSyncErrorResponse.php
@@ -10,33 +10,32 @@ namespace QuickBooksOnline\API\Data;
                 Product: QBW
                 Description: Provides a wrapper for SyncError for Conflict API Response
                 Consists of list of SyncError objects
-
  */
 class IPPSyncErrorResponse
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSyncErrorResponse', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSyncErrorResponse', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSyncErrorResponse', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSyncErrorResponse', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition
@@ -52,6 +51,7 @@ class IPPSyncErrorResponse
      * @var com\intuit\schema\finance\v3\IPPSyncError
      */
     public $SyncError;
+
     /**
      * @Definition
                            Product: QBW
@@ -62,6 +62,7 @@ class IPPSyncErrorResponse
      * @var string
      */
     public $latestUploadTime;
+
     /**
      * @Definition Specifies the starting row number in this result
      * @xmlType attribute
@@ -69,6 +70,7 @@ class IPPSyncErrorResponse
      * @var integer
      */
     public $startPosition;
+
     /**
      * @Definition Specifies the number of records in this result
      * @xmlType attribute
@@ -76,6 +78,7 @@ class IPPSyncErrorResponse
      * @var integer
      */
     public $maxResults;
+
     /**
      * @Definition Specifies the total count of records that satisfy the filter condition
      * @xmlType attribute
@@ -83,4 +86,6 @@ class IPPSyncErrorResponse
      * @var integer
      */
     public $totalCount;
-} // end class IPPSyncErrorResponse
+}//end class
+
+ // end class IPPSyncErrorResponse

--- a/src/Data/IPPSyncErrorType.php
+++ b/src/Data/IPPSyncErrorType.php
@@ -9,36 +9,35 @@ namespace QuickBooksOnline\API\Data;
  * @xmlDefinition
         Product: QBW
         Description: must be either of the following values
-
  */
 class IPPSyncErrorType
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSyncErrorType', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSyncErrorType', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSyncErrorType', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSyncErrorType', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPSyncErrorType

--- a/src/Data/IPPSyncObject.php
+++ b/src/Data/IPPSyncObject.php
@@ -7,35 +7,34 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPSyncObject
  * @var IPPSyncObject
  * @xmlDefinition
-            	Product: QBW
-            	Description: SyncObject that has an error
-
+                Product: QBW
+                Description: SyncObject that has an error
  */
 class IPPSyncObject
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSyncObject', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSyncObject', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSyncObject', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPSyncObject', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition Any IntuitEntity derived object like Customer, Invoice can be part of response
@@ -46,6 +45,7 @@ class IPPSyncObject
      * @var IntuitObject
      */
     public $IntuitObject;
+
     /**
      * @Definition  Fault or Object should be returned
      * @xmlType element
@@ -56,4 +56,6 @@ class IPPSyncObject
      * @var com\intuit\schema\finance\v3\IPPFault
      */
     public $Fault;
-} // end class IPPSyncObject
+}//end class
+
+ // end class IPPSyncObject

--- a/src/Data/IPPSyncType.php
+++ b/src/Data/IPPSyncType.php
@@ -9,36 +9,35 @@ namespace QuickBooksOnline\API\Data;
  * @xmlDefinition
         Product: QBW
         Description: must be either upload or writeback
-
  */
 class IPPSyncType
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPSyncType', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSyncType', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPSyncType', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPSyncType', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPSyncType

--- a/src/Data/IPPTDSLineDetail.php
+++ b/src/Data/IPPTDSLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTDSLineDetail
  * @xmlDefinition
                 Product: QBO
-                Description: TDS line detail for the transaction.
+                Description: TDS line detail for the
+                transaction.
 
  */
 class IPPTDSLineDetail
@@ -23,24 +24,25 @@ class IPPTDSLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTDSLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTDSLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTDSLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTDSLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: QBO
-                        Description: Reference to TDS account associated with this transaction
+                        Description: Reference to TDS account
+                        associated with this transaction
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -52,7 +54,8 @@ class IPPTDSLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: TDS section type of the transaction.
+                        Description: TDS section type of the
+                        transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +67,8 @@ class IPPTDSLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: Extension place holder for TDSLineDetail
+                        Description: Extension place holder
+                        for TDSLineDetail
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPTDSMetadata.php
+++ b/src/Data/IPPTDSMetadata.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTDSMetadata
  * @xmlDefinition
                 Product: QBO
-                Description: Describes metadata associated with TDS entity.
+                Description: Describes metadata
+                associated with TDS entity.
 
  */
 class IPPTDSMetadata extends IPPIntuitEntity
@@ -23,20 +24,20 @@ class IPPTDSMetadata extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTDSMetadata', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTDSMetadata', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTDSMetadata', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTDSMetadata', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBO

--- a/src/Data/IPPTask.php
+++ b/src/Data/IPPTask.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTask
  * @xmlDefinition
                 Product: QBW
-                Description: A specific task to be completed, maps to a ToDo record in QuickBooks.
+                Description: A specific task to be
+                completed, maps to a ToDo record in QuickBooks.
 
  */
 class IPPTask extends IPPIntuitEntity
@@ -23,24 +24,25 @@ class IPPTask extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTask', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTask', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTask', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTask', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBW
-                                Description: The actual content of the task reminder
+                                Description: The actual content of
+                                the task reminder
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +78,8 @@ class IPPTask extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: True if the task has been completed
+                                Description: True if the task has
+                                been completed
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -88,7 +91,8 @@ class IPPTask extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: The date to remind the user of this task
+                                Description: The date to remind the
+                                user of this task
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -98,7 +102,8 @@ class IPPTask extends IPPIntuitEntity
      */
     public $ReminderDate;
     /**
-     * @Definition Internal use only: extension place holder for Task
+     * @Definition Internal use only: extension place holder for
+                                Task
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPTaxAgency.php
+++ b/src/Data/IPPTaxAgency.php
@@ -23,20 +23,20 @@ class IPPTaxAgency extends IPPVendor
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxAgency', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxAgency', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxAgency', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxAgency', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -103,15 +103,6 @@ class IPPTaxAgency extends IPPVendor
      * @var boolean
      */
     public $TaxTrackedOnSales;
-
-    /**
-    * @xmlType element
-    * @xmlNamespace http://schema.intuit.com/finance/v3
-    * @xmlMinOccurs 0
-    * @xmlName LastFileDate
-    * @var string
-    */
-    public $LastFileDate;
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -128,6 +119,19 @@ class IPPTaxAgency extends IPPVendor
      * @var boolean
      */
     public $TaxOnTax;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: This specifies the last filing date for this tax agency.
+                                InputType: QBO: ReadOnly
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName LastFileDate
+     * @var string
+     */
+    public $LastFileDate;
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPTaxApplicableOnEnum.php
+++ b/src/Data/IPPTaxApplicableOnEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTaxApplicableOnEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of tax applicable on Journal Entry (Sales/Purchase)
+                Description: Enumeration of tax
+                applicable on Journal Entry (Sales/Purchase)
 
  */
 class IPPTaxApplicableOnEnum
@@ -23,22 +24,22 @@ class IPPTaxApplicableOnEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxApplicableOnEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxApplicableOnEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxApplicableOnEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxApplicableOnEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTaxApplicableOnEnum

--- a/src/Data/IPPTaxCode.php
+++ b/src/Data/IPPTaxCode.php
@@ -8,7 +8,15 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTaxCode
  * @xmlDefinition
                 Product: ALL
-                Description: A tax code is used to track the taxable or non-taxable status of products, services, and customers. You can assign a sales tax code to each of your products, services, and customers based on their taxable or non-taxable status. You can then use these codes to generate reports that provide information to the tax agencies about the taxable or non-taxable status of certain sales. [br]See [a href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01100_Global_Tax_Model"]Global Tax Model[/a].
+                Description: A tax code is used to
+                track the taxable or non-taxable status of products, services, and
+                customers. You can assign a sales tax code to each of your products,
+                services, and customers based on their taxable or non-taxable
+                status. You can then use these codes to generate reports that
+                provide information to the tax agencies about the taxable or
+                non-taxable status of certain sales. [br]See [a
+                href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01100_Global_Tax_Model"]Global
+                Tax Model[/a].
 
  */
 class IPPTaxCode extends IPPIntuitEntity
@@ -23,26 +31,30 @@ class IPPTaxCode extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxCode', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxCode', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxCode', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxCode', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBW
-                                Description: User recognizable name for the tax sales code.[br/]Max. Length: 3 characters.[br /]Required for the Create request.
+                                Description: User recognizable name
+                                for the tax sales code.[br/]Max. Length: 3 characters.[br
+                                /]Required for the Create request.
                                 Product: QBO
-                                Description: User recognizable name for the tax sales code.[br/]Max. Length: 10 characters.
+                                Description: User
+                                recognizable name for the tax sales code.[br/]Max. Length: 10
+                                characters.
                                 Required: ALL
                                 Filterable: ALL
                                 Sortable: ALL
@@ -57,7 +69,9 @@ class IPPTaxCode extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: User entered description for the sales tax code.[br/]Max Length: 31 characters.
+                                Description: User entered
+                                description for the sales tax code.[br/]Max Length: 31
+                                characters.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -69,7 +83,9 @@ class IPPTaxCode extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: False if inactive. Inactive sales tax codes may be hidden from display and may not be used on financial transactions.
+                                Description: False if inactive.
+                                Inactive sales tax codes may be hidden from display and may not
+                                be used on financial transactions.
                                 Filterable: ALL
 
      * @xmlType element
@@ -82,7 +98,21 @@ class IPPTaxCode extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: False or null means meaning non-taxable (default).  True means taxable.
+                                Description: True if Taxcode needs to be hidden. Active tax codes can be hidden from the display using this.
+                                Filterable: ALL
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName Hidden
+     * @var boolean
+     */
+    public $Hidden;
+    /**
+     * @Definition
+                                Product: QBW
+                                Description: False or null means
+                                meaning non-taxable (default). True means taxable.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -94,7 +124,9 @@ class IPPTaxCode extends IPPIntuitEntity
     /**
      * @Definition
                                 Product:QBW
-                                Description: True if this tax code represents a group of tax rates (a desktop TaxGroupItem), false if it represents a QuickBooks US TaxCode.
+                                Description: True if this tax code
+                                represents a group of tax rates (a desktop TaxGroupItem), false
+                                if it represents a QuickBooks US TaxCode.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -106,7 +138,9 @@ class IPPTaxCode extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: List of references to tax rates that apply for sales transactions when this tax code is used.
+                                Description: List of references to
+                                tax rates that apply for sales transactions when this tax code
+                                is used.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -118,7 +152,9 @@ class IPPTaxCode extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: List of references to tax rates that apply for purchase transactions when this tax code is used.
+                                Description: List of references to
+                                tax rates that apply for purchase transactions when this tax
+                                code is used.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -130,7 +166,8 @@ class IPPTaxCode extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: List of references to adjustment tax rates that apply to the transaction.
+                                Description: List of references to
+                                adjustment tax rates that apply to the transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -142,7 +179,8 @@ class IPPTaxCode extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Internal use only: extension place holder for TaxCode
+                                Description: Internal use only:
+                                extension place holder for TaxCode
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPTaxFormTypeEnum.php
+++ b/src/Data/IPPTaxFormTypeEnum.php
@@ -8,7 +8,9 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTaxFormTypeEnum
  * @xmlDefinition
                 Product: QBO
-                Description: Tax Form Type holds data related to Tax Information (Tax Form Type) based on Regional compliance laws. Applicable for IN region currently. Can be used to extend for other Regions.
+                Description: Tax Form Type holds data related to Tax Information (Tax Form Type)
+                based on Regional compliance laws. Applicable for IN region
+                currently. Can be used to extend for other Regions.
 
  */
 class IPPTaxFormTypeEnum
@@ -23,22 +25,22 @@ class IPPTaxFormTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxFormTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxFormTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxFormTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxFormTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTaxFormTypeEnum

--- a/src/Data/IPPTaxLineDetail.php
+++ b/src/Data/IPPTaxLineDetail.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTaxLineDetail
  * @xmlDefinition
                 Product: ALL
-                Description: Tax detail for a transaction line.
+                Description: Tax detail for a
+                transaction line.
 
  */
 class IPPTaxLineDetail
@@ -23,33 +24,54 @@ class IPPTaxLineDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxLineDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxLineDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxLineDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxLineDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: QBW
-                        Description: Reference to a TaxRate. For all editions of QuickBooks, for TaxLineDetail line types that apply a specific TaxRate to the preceding line of the transaction, this
-                        is a reference to that TaxRate. For a TaxLineDetail in a TxnTaxDetail, where the TxnTaxCodeRef is set, the TaxRate referenced here MUST also be
-                        one of the rates in the referenced tax code's rate list (either the SalesTaxRateList or the PurchaseTaxRateList) that applies to the transaction type.[br /]
-                        For international editions of QuickBooks, for a TaxLineDetail in a TxnTaxDetail, the rate referenced here must be referenced by a TaxCode used on  a transaction
-                        line. Any given rate may only be listed once.[br]See [a href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01100_Global_Tax_Model"]Global Tax Model[/a].
+                        Description: Reference to a TaxRate.
+                        For all editions of QuickBooks, for TaxLineDetail line types that
+                        apply a specific TaxRate to the preceding line of the transaction,
+                        this
+                        is a reference to that TaxRate. For a TaxLineDetail in a
+                        TxnTaxDetail, where the TxnTaxCodeRef is set, the TaxRate
+                        referenced here MUST also be
+                        one of the rates in the referenced tax code's rate list (either the
+                        SalesTaxRateList or the PurchaseTaxRateList) that applies to the
+                        transaction type.[br /]
+                        For international editions of QuickBooks,
+                        for a TaxLineDetail in a TxnTaxDetail, the rate referenced here
+                        must be referenced by a TaxCode used on a transaction
+                        line. Any given rate may only be listed once.[br]See [a
+                        href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01100_Global_Tax_Model"]Global
+                        Tax Model[/a].
                         Product: QBO
-                        Description: For US editions of QuickBooks Online, and in TxnTaxDetail only, this references the TaxRate applied to the entire transaction.[br /]
-                        For international editions of QuickBooks Online, for a TaxLineDetail in a TxnTaxDetail, where the TxnTaxCodeRef is set, the TaxRate referenced
-                        here MUST also be one of the rates in the referenced tax code's rate list (either the SalesTaxRateList or the PurchaseTaxRateList) that applies to the
-                        transaction type. Any given rate may only be listed once.[br /]Does not apply to a TaxLineDetail apart from a TxnTaxDetail.[br]See [a href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01100_Global_Tax_Model"]Global Tax Model[/a].
+                        Description: For US editions of
+                        QuickBooks Online, and in TxnTaxDetail only, this references the
+                        TaxRate applied to the entire transaction.[br /]
+                        For international
+                        editions of QuickBooks Online, for a TaxLineDetail in a
+                        TxnTaxDetail, where the TxnTaxCodeRef is set, the TaxRate
+                        referenced
+                        here MUST also be one of the rates in the referenced tax code's rate
+                        list (either the SalesTaxRateList or the PurchaseTaxRateList) that
+                        applies to the
+                        transaction type. Any given rate may only be listed once.[br /]Does not apply
+                        to a TaxLineDetail apart from a TxnTaxDetail.[br]See [a
+                        href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01100_Global_Tax_Model"]Global
+                        Tax Model[/a].
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -62,7 +84,8 @@ class IPPTaxLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: True if the sales tax is expressed as a percentage; false if expressed as a number amount.
+                        Description: True if the sales tax is
+                        expressed as a percentage; false if expressed as a number amount.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -74,7 +97,8 @@ class IPPTaxLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Numerical expression of the sales tax percent. For example, use "8.5" not "0.085".
+                        Description: Numerical expression of
+                        the sales tax percent. For example, use "8.5" not "0.085".
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -86,9 +110,14 @@ class IPPTaxLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: This is taxable amount on the total of the applicable tax rates
-                        If TaxRate is applicable on two lines, the taxableamount represents total of the two lines for which this rate is applied
-                        This is different from the Line.Amount which represent the final tax amount after the tax has been applied
+                        Description: This is taxable amount
+                        on the total of the applicable tax rates
+                        If TaxRate is applicable
+                        on two lines, the taxableamount represents total of the two lines
+                        for which this rate is applied
+                        This is different from the
+                        Line.Amount which represent the final tax amount after the tax has
+                        been applied
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -101,7 +130,8 @@ class IPPTaxLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: This is the amount which also includes tax.
+                        Description: This is the amount which
+                        also includes tax.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -114,7 +144,9 @@ class IPPTaxLineDetail
     /**
      * @Definition
                         Product: QBO
-                        Description: This holds the difference between the actual tax and overridden amount supplied by the user.
+                        Description: This holds the
+                        difference between the actual tax and overridden amount supplied
+                        by the user.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -127,7 +159,8 @@ class IPPTaxLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Date when the service is performed.
+                        Description: Date when the service is
+                        performed.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -139,7 +172,8 @@ class IPPTaxLineDetail
     /**
      * @Definition
                         Product: ALL
-                        Description: Internal use only: extension place holder for TaxLine.
+                        Description: Internal use only:
+                        extension place holder for TaxLine.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPTaxPrefs.php
+++ b/src/Data/IPPTaxPrefs.php
@@ -19,20 +19,20 @@ class IPPTaxPrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxPrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxPrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxPrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxPrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -41,20 +41,29 @@ class IPPTaxPrefs
      * @var boolean
      */
     public $UsingSalesTax;
-
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
-     * @xmlName $PartnerTaxEnabled
+     * @xmlName PartnerTaxEnabled
      * @var boolean
      */
     public $PartnerTaxEnabled;
-
+    /**
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName HideTaxManagement
+     * @var boolean
+     */
+    public $HideTaxManagement;
     /**
      * @Definition
                             Product: QBW
-                            Description: US only? reference to a TaxCode entity where the group field of the referenced entity is true, that is, a TaxCode representing a list of tax rates that should apply by default.
+                            Description: US only? reference to a
+                            TaxCode entity where the group field of the referenced entity is
+                            true, that is, a TaxCode representing a list of tax rates that
+                            should apply by default.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -66,7 +75,8 @@ class IPPTaxPrefs
     /**
      * @Definition
                             Product: QBW
-                            Description: US-only? reference to a TaxRate entity indicating the sales tax to apply by default.
+                            Description: US-only? reference to a
+                            TaxRate entity indicating the sales tax to apply by default.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -91,7 +101,8 @@ class IPPTaxPrefs
      * @Definition
                         Product: QBW
                         [b]QuickBooks Notes[/b][br /]
-                        Max Length: 3
+                        Max
+                        Length: 3
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -104,7 +115,8 @@ class IPPTaxPrefs
      * @Definition
                         Product: QBW
                         [b]QuickBooks Notes[/b][br /]
-                        Max Length: 3
+                        Max
+                        Length: 3
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPTaxRate.php
+++ b/src/Data/IPPTaxRate.php
@@ -8,7 +8,10 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTaxRate
  * @xmlDefinition
                 Product: ALL
-                Description: A sales tax rate specifies the tax rate for the specific TaxCode.[br]See [a href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01100_Global_Tax_Model"]Global Tax Model[/a].
+                Description: A sales tax rate specifies
+                the tax rate for the specific TaxCode.[br]See [a
+                href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01100_Global_Tax_Model"]Global
+                Tax Model[/a].
 
  */
 class IPPTaxRate extends IPPIntuitEntity
@@ -23,24 +26,26 @@ class IPPTaxRate extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxRate', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxRate', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxRate', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxRate', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: QBW
-                                Description: User recognizable name for the tax rate.[br /]Max. Length: 31 characters.[br /]Required for the Create request.
+                                Description: User recognizable name
+                                for the tax rate.[br /]Max. Length: 31 characters.[br /]Required
+                                for the Create request.
                                 Required: QBW
                                 ValidRange: QBW: Max=31
                                 Filterable: QBW
@@ -55,7 +60,8 @@ class IPPTaxRate extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: User entered description for the tax rate.[br /]Max Length: 4000 characters.
+                                Description: User entered
+                                description for the tax rate.[br /]Max Length: 4000 characters.
                                 ValidRange: QBW: Max=4000
 
      * @xmlType element
@@ -68,7 +74,9 @@ class IPPTaxRate extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: False or null if inactive. Inactive sales rate codes may be hidden from display and may not be used on financial transactions.
+                                Description: False or null if
+                                inactive. Inactive sales rate codes may be hidden from display
+                                and may not be used on financial transactions.
                                 Filterable: QBW
 
      * @xmlType element
@@ -94,7 +102,9 @@ class IPPTaxRate extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Represents Agency Reference, Vendor Reference in case of QBW, Agency in case of QBO.
+                                Description: Represents Agency
+                                Reference, Vendor Reference in case of QBW, Agency in case of
+                                QBO.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -106,7 +116,8 @@ class IPPTaxRate extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: TaxReturnLine is representative of SalesTaxReturnLine reference
+                                Description: TaxReturnLine is
+                                representative of SalesTaxReturnLine reference
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -118,7 +129,8 @@ class IPPTaxRate extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Effective list rates for different date ranges
+                                Description: Effective list rates
+                                for different date ranges
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -131,9 +143,12 @@ class IPPTaxRate extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Used for Zero rates for EC VAT.
-                                How it is used: VAT registered Businesses who receive goods/services (acquisitions) from other EU countries,
-                                will need to calculate the VAT due, but not paid, on these acquisitions. The rate of VAT payable is the same that would
+                                Description: Used for Zero rates
+                                for EC VAT.
+                                How it is used: VAT registered Businesses who receive
+                                goods/services (acquisitions) from other EU countries,
+                                will need to calculate the VAT due, but not paid, on these
+                                acquisitions. The rate of VAT payable is the same that would
                                 have been paid if the goods had been supplied by a UK supplier.
 
      * @xmlType element
@@ -146,7 +161,8 @@ class IPPTaxRate extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: DisplayType of a tax rate, configuration of editability and  display on forms
+                                Description: DisplayType of a tax
+                                rate, configuration of editability and display on forms
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -158,7 +174,8 @@ class IPPTaxRate extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Internal use only: extension place holder for TaxRate
+                                Description: Internal use only:
+                                extension place holder for TaxRate
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPTaxRateApplicableOnEnum.php
+++ b/src/Data/IPPTaxRateApplicableOnEnum.php
@@ -9,36 +9,39 @@ namespace QuickBooksOnline\API\Data;
  * @xmlDefinition
             Product: QBO
             Description: Enumeration of  transaction type a given tax rate can be applied to
-
  */
 class IPPTaxRateApplicableOnEnum
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxRateApplicableOnEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxRateApplicableOnEnum', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxRateApplicableOnEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxRateApplicableOnEnum', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
+    }//end __construct()
+
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
-} // end class IPPTaxRateApplicableOnEnum
+    public $value;
+}//end class
+
+ // end class IPPTaxRateApplicableOnEnum

--- a/src/Data/IPPTaxRateDetail.php
+++ b/src/Data/IPPTaxRateDetail.php
@@ -19,20 +19,20 @@ class IPPTaxRateDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxRateDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxRateDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxRateDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxRateDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPTaxRateDetails.php
+++ b/src/Data/IPPTaxRateDetails.php
@@ -9,33 +9,32 @@ namespace QuickBooksOnline\API\Data;
  * @xmlDefinition
                 Product: QBO
                 Description: TaxRate details
-
  */
 class IPPTaxRateDetails
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxRateDetails', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxRateDetails', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxRateDetails', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxRateDetails', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition
@@ -50,6 +49,7 @@ class IPPTaxRateDetails
      * @var string
      */
     public $TaxRateName;
+
     /**
      * @Definition
                         Product: QBO
@@ -63,6 +63,7 @@ class IPPTaxRateDetails
      * @var string
      */
     public $TaxRateId;
+
     /**
      * @Definition
                         Product: QBO
@@ -76,6 +77,7 @@ class IPPTaxRateDetails
      * @var float
      */
     public $RateValue;
+
     /**
      * @Definition
                         Product: QBO
@@ -89,6 +91,7 @@ class IPPTaxRateDetails
      * @var string
      */
     public $TaxAgencyId;
+
     /**
      * @Definition
                         Product: QBO
@@ -102,4 +105,6 @@ class IPPTaxRateDetails
      * @var com\intuit\schema\finance\v3\IPPTaxRateApplicableOnEnum
      */
     public $TaxApplicableOn;
-} // end class IPPTaxRateDetails
+}//end class
+
+ // end class IPPTaxRateDetails

--- a/src/Data/IPPTaxRateDisplayTypeEnum.php
+++ b/src/Data/IPPTaxRateDisplayTypeEnum.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType string
  * @xmlName IPPTaxRateDisplayTypeEnum
  * @var IPPTaxRateDisplayTypeEnum
- * @xmlDefinition  Product: QBO Description: Enumeration of  TaxRateDisplayType
+ * @xmlDefinition  Product: QBO Description: Enumeration of
+                TaxRateDisplayType
  */
 class IPPTaxRateDisplayTypeEnum
 {
@@ -20,22 +21,22 @@ class IPPTaxRateDisplayTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxRateDisplayTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxRateDisplayTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxRateDisplayTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxRateDisplayTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTaxRateDisplayTypeEnum

--- a/src/Data/IPPTaxRateList.php
+++ b/src/Data/IPPTaxRateList.php
@@ -19,24 +19,25 @@ class IPPTaxRateList
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxRateList', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxRateList', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxRateList', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxRateList', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: All
-                        Description: TaxRateDetail that specifies qualified detail of TaxRate
+                        Description: TaxRateDetail that
+                        specifies qualified detail of TaxRate
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -49,7 +50,9 @@ class IPPTaxRateList
     /**
      * @Definition
                     Product: QBW
-                    Description: opaque internal string used to correlate the rate list with a QBW TaxGroup item to support mod of TaxCodes in global tax
+                    Description: opaque internal string
+                    used to correlate the rate list with a QBW TaxGroup item to support
+                    mod of TaxCodes in global tax
 
      * @xmlType attribute
      * @xmlName originatingGroupId

--- a/src/Data/IPPTaxReportBasisTypeEnum.php
+++ b/src/Data/IPPTaxReportBasisTypeEnum.php
@@ -23,22 +23,22 @@ class IPPTaxReportBasisTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxReportBasisTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxReportBasisTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxReportBasisTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxReportBasisTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTaxReportBasisTypeEnum

--- a/src/Data/IPPTaxReturn.php
+++ b/src/Data/IPPTaxReturn.php
@@ -1,0 +1,161 @@
+<?php
+namespace QuickBooksOnline\API\Data;
+
+/**
+ * @xmlNamespace http://schema.intuit.com/finance/v3
+ * @xmlType IntuitEntity
+ * @xmlName IPPTaxReturn
+ * @var IPPTaxReturn
+ * @xmlDefinition
+                Product: QBO
+                Description: Represents a Tax Return
+                that is filed with a Tax Agency.
+
+ */
+class IPPTaxReturn extends IPPIntuitEntity
+{
+
+        /**
+        * Initializes this object, optionally with pre-defined property values
+        *
+        * Initializes this object and it's property members, using the dictionary
+        * of key/value pairs passed as an optional argument.
+        *
+        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+        * @param boolean $verbose specifies whether object should echo warnings
+        */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxReturn', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxReturn', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
+                }
+            }
+        }
+    }
+
+    
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: True when this filing
+                                is an upcoming Filing for a currently Open Filing Period. False
+                                otherwise.
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName UpcomingFiling
+     * @var boolean
+     */
+    public $UpcomingFiling;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: Start date of the
+                                Filing.
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName StartDate
+     * @var string
+     */
+    public $StartDate;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: End date of the
+                                Filing.
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName EndDate
+     * @var string
+     */
+    public $EndDate;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: Date of the Filing.
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName FileDate
+     * @var string
+     */
+    public $FileDate;
+    /**
+     * @Definition Specifies the final Tax Amount due to the Tax
+                                Agency for a Filing
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName NetTaxAmountDue
+     * @var float
+     */
+    public $NetTaxAmountDue;
+    /**
+     * @Definition Specifies the FRS Amount due to the Tax Agency
+                                for a Filing Period. Applicable for UK only.
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName FlatRateSavingsAmountDue
+     * @var float
+     */
+    public $FlatRateSavingsAmountDue;
+    /**
+     * @Definition Specifies the PayGWithheld Amount due to the
+                                Tax Agency for a Filing Period. Applicable for AU only.
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName PayGWithheldAmount
+     * @var float
+     */
+    public $PayGWithheldAmount;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: Represents the Agency
+                                of which this TaxReturn is a part.
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName AgencyRef
+     * @var com\intuit\schema\finance\v3\IPPReferenceType
+     */
+    public $AgencyRef;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: Represents the status of the filing of the tax return
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName TaxReturnStatus
+     * @var com\intuit\schema\finance\v3\IPPTaxReturnStatusEnum
+     */
+    public $TaxReturnStatus;
+    /**
+     * @Definition
+                                Product: QBO
+                                Description: Represents the tax return code with the partner
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName TaxReturnCode
+     * @var string
+     */
+    public $TaxReturnCode;
+} // end class IPPTaxReturn

--- a/src/Data/IPPTaxReturnStatusEnum.php
+++ b/src/Data/IPPTaxReturnStatusEnum.php
@@ -4,14 +4,11 @@ namespace QuickBooksOnline\API\Data;
 /**
  * @xmlNamespace http://schema.intuit.com/finance/v3
  * @xmlType string
- * @xmlName IPPBudgetTypeEnum
- * @var IPPBudgetTypeEnum
- * @xmlDefinition
-                Product: ALL
-                Description: Enumeration of Budget Types
-
+ * @xmlName IPPTaxReturnStatusEnum
+ * @var IPPTaxReturnStatusEnum
+ * @xmlDefinition Enumeration of the filing status that a TaxReturn can have
  */
-class IPPBudgetTypeEnum
+class IPPTaxReturnStatusEnum
 {
 
         /**
@@ -26,7 +23,7 @@ class IPPBudgetTypeEnum
     public function __construct($keyValInitializers = array(), $verbose = false)
     {
         foreach ($keyValInitializers as $initPropName => $initPropVal) {
-            if (property_exists('IPPBudgetTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPBudgetTypeEnum', $initPropName)) {
+            if (property_exists('IPPTaxReturnStatusEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxReturnStatusEnum', $initPropName)) {
                 $this->{$initPropName} = $initPropVal;
             } else {
                 if ($verbose) {
@@ -41,4 +38,4 @@ class IPPBudgetTypeEnum
          * @var string
          */
     public $value;
-} // end class IPPBudgetTypeEnum
+} // end class IPPTaxReturnStatusEnum

--- a/src/Data/IPPTaxService.php
+++ b/src/Data/IPPTaxService.php
@@ -11,28 +11,28 @@ namespace QuickBooksOnline\API\Data;
 class IPPTaxService
 {
 
+
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxService', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxService', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = [], $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxService', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxService', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+            } else {
+                if ($verbose) {
+                        echo "Property does not exist ($initPropName) in class (".get_class($this).')';
                 }
             }
         }
-
+    }//end __construct()
 
     /**
      * @Definition
@@ -47,6 +47,7 @@ class IPPTaxService
      * @var string
      */
     public $TaxCode;
+
     /**
      * @Definition
                         Product: QBO
@@ -60,6 +61,7 @@ class IPPTaxService
      * @var string
      */
     public $TaxCodeId;
+
     /**
      * @Definition
                         Product: QBO
@@ -73,6 +75,7 @@ class IPPTaxService
      * @var com\intuit\schema\finance\v3\IPPTaxRateDetails
      */
     public $TaxRateDetails;
+
     /**
      * @Definition  Fault or Object should be returned
      * @xmlType element
@@ -83,4 +86,6 @@ class IPPTaxService
      * @var com\intuit\schema\finance\v3\IPPFault
      */
     public $Fault;
-} // end class IPPTaxService
+}//end class
+
+ // end class IPPTaxService

--- a/src/Data/IPPTaxTypeApplicablityEnum.php
+++ b/src/Data/IPPTaxTypeApplicablityEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTaxTypeApplicablityEnum
  * @xmlDefinition
                 Product: ALL
-                Description: TaxTypeApplicability enumeration
+                Description: TaxTypeApplicability
+                enumeration
 
  */
 class IPPTaxTypeApplicablityEnum
@@ -23,22 +24,22 @@ class IPPTaxTypeApplicablityEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTaxTypeApplicablityEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTaxTypeApplicablityEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTaxTypeApplicablityEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTaxTypeApplicablityEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTaxTypeApplicablityEnum

--- a/src/Data/IPPTelephoneDeviceTypeEnum.php
+++ b/src/Data/IPPTelephoneDeviceTypeEnum.php
@@ -23,22 +23,22 @@ class IPPTelephoneDeviceTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTelephoneDeviceTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTelephoneDeviceTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTelephoneDeviceTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTelephoneDeviceTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTelephoneDeviceTypeEnum

--- a/src/Data/IPPTelephoneNumber.php
+++ b/src/Data/IPPTelephoneNumber.php
@@ -23,20 +23,20 @@ class IPPTelephoneNumber
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTelephoneNumber', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTelephoneNumber', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTelephoneNumber', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTelephoneNumber', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: QBW

--- a/src/Data/IPPTelephoneNumberTypeEnum.php
+++ b/src/Data/IPPTelephoneNumberTypeEnum.php
@@ -23,22 +23,22 @@ class IPPTelephoneNumberTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTelephoneNumberTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTelephoneNumberTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTelephoneNumberTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTelephoneNumberTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTelephoneNumberTypeEnum

--- a/src/Data/IPPTemplateName.php
+++ b/src/Data/IPPTemplateName.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType IntuitEntity
  * @xmlName IPPTemplateName
  * @var IPPTemplateName
- * @xmlDefinition The name of a template used for a specific form presentation.
+ * @xmlDefinition The name of a template used for a specific form
+                presentation.
  */
 class IPPTemplateName extends IPPIntuitEntity
 {
@@ -20,23 +21,24 @@ class IPPTemplateName extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTemplateName', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTemplateName', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTemplateName', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTemplateName', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition User recognizable name for the Template name.[br /]
-                                 [br /]
+     * @Definition User recognizable name for the Template
+                                name.[br /]
+                                [br /]
                                 Required for the create operation. [br /]
                                 Max Length: 31
 
@@ -48,7 +50,9 @@ class IPPTemplateName extends IPPIntuitEntity
      */
     public $Name;
     /**
-     * @Definition Whether or not active inactive templates may be hidden from most display purposes and may not be used on financial tansactions.
+     * @Definition Whether or not active inactive templates may be
+                                hidden from most display purposes and may not be used on
+                                financial tansactions.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPTemplateTypeEnum.php
+++ b/src/Data/IPPTemplateTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTemplateTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of template types.
+                Description: Enumeration of template
+                types.
 
  */
 class IPPTemplateTypeEnum
@@ -23,22 +24,22 @@ class IPPTemplateTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTemplateTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTemplateTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTemplateTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTemplateTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTemplateTypeEnum

--- a/src/Data/IPPTerm.php
+++ b/src/Data/IPPTerm.php
@@ -8,7 +8,16 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTerm
  * @xmlDefinition
                 Product: ALL
-                Description: The Term entity represents the terms under which a sale is made, typically expressed in the form of days due after the goods are received.  Optionally, a discount of the total amount may be applied if payment is made within a stipulated time.  For example, net 30 indicates that payment is due within 30 days.  A term of 2%/15 net 60 indicates that payment is due within 60 days,  with a discount of 2%  if payment is made within 15 days.   Term also supports: an absolute due date, a number of days from a start date, a percent discount, or an absolute discount.
+                Description: The Term entity represents
+                the terms under which a sale is made, typically expressed in the
+                form of days due after the goods are received. Optionally, a
+                discount of the total amount may be applied if payment is made
+                within a stipulated time. For example, net 30 indicates that payment
+                is due within 30 days. A term of 2%/15 net 60 indicates that payment
+                is due within 60 days, with a discount of 2% if payment is made
+                within 15 days. Term also supports: an absolute due date, a number
+                of days from a start date, a percent discount, or an absolute
+                discount.
 
  */
 class IPPTerm extends IPPIntuitEntity
@@ -23,24 +32,25 @@ class IPPTerm extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTerm', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTerm', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTerm', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTerm', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL
-                                Description: User recognizable name for the term, for example, "Net 30".
+                                Description: User recognizable name
+                                for the term, for example, "Net 30".
                                 ValidRange: QBW: max=31
                                 ValidRange: QBO: Max=31
                                 Required: ALL
@@ -57,7 +67,8 @@ class IPPTerm extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: If true, this entity is currently enabled for use by QuickBooks.
+                                Description: If true, this entity
+                                is currently enabled for use by QuickBooks.
                                 Filterable: ALL
                                 Default Value: true
 
@@ -71,7 +82,10 @@ class IPPTerm extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Type of the Sales Term. Valid values: Standard or DateDriven, as defined by SalesTermTypeEnum. [br /] If dueDays is not null, the Type is Standard else DateDriven.
+                                Description: Type of the Sales
+                                Term. Valid values: Standard or DateDriven, as defined by
+                                SalesTermTypeEnum. [br /] If dueDays is not null, the Type is
+                                Standard else DateDriven.
                                 InputType: ALL: ReadOnly
 
      * @xmlType element
@@ -84,7 +98,9 @@ class IPPTerm extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Discount percentage available against an amount if paid within the days specified by DiscountDays.
+                                Description: Discount percentage
+                                available against an amount if paid within the days specified by
+                                DiscountDays.
                                 ValidRange: ALL: Min=0, Max=100
 
      * @xmlType element
@@ -97,10 +113,15 @@ class IPPTerm extends IPPIntuitEntity
     /**
      * @Definition
                                         Product: ALL
-                                        Description: Number of days from delivery of goods or services until the payment is due.
-                                        Business Rules: QBO: [li] This value is required if DayOfMonthDue is not specified. [/li] [li] If DueDays is specified, only DiscountDays and DiscountPercent can be additionally specified.[/li]
+                                        Description: Number of days from
+                                        delivery of goods or services until the payment is due.
+                                        Business Rules: QBO: [li] This value is required if
+                                        DayOfMonthDue is not specified. [/li] [li] If DueDays is
+                                        specified, only DiscountDays and DiscountPercent can be
+                                        additionally specified.[/li]
                                         Required: QBO
-                                        ValidRange: QBO: Min=0 Max=999
+                                        ValidRange: QBO:
+                                        Min=0 Max=999
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -112,8 +133,10 @@ class IPPTerm extends IPPIntuitEntity
     /**
      * @Definition
                                         Product: ALL
-                                        Description: Discount applies if paid within this number of days.
-                                        Business Rules: [li] This value is used only when DueDays is specified. [/li]
+                                        Description: Discount applies if
+                                        paid within this number of days.
+                                        Business Rules: [li] This
+                                        value is used only when DueDays is specified. [/li]
                                         ValidRange: QBO: Min=0 Max=999
 
      * @xmlType element
@@ -126,8 +149,12 @@ class IPPTerm extends IPPIntuitEntity
     /**
      * @Definition
                                         Product: ALL
-                                        Description: Payment must be received by this day of the month.
-                                        Business Rules: QBO: [li] This value is used only when DueDays is not specified.[/li] [li] Required for the Create request when DueDays is not specified.[/li]
+                                        Description: Payment must be
+                                        received by this day of the month.
+                                        Business Rules: QBO: [li]
+                                        This value is used only when DueDays is not specified.[/li]
+                                        [li] Required for the Create request when DueDays is not
+                                        specified.[/li]
                                         ValidRange: QBO: Min=1 Max=31
 
      * @xmlType element
@@ -140,8 +167,10 @@ class IPPTerm extends IPPIntuitEntity
     /**
      * @Definition
                                         Product: ALL
-                                        Description: Payment due next month if issued that many days before the DayOfMonthDue.
-                                        Business Rules: QBO: [li] Required for the Create request when DueDays is not specified.[/li]
+                                        Description: Payment due next
+                                        month if issued that many days before the DayOfMonthDue.
+                                        Business Rules: QBO: [li] Required for the Create request when
+                                        DueDays is not specified.[/li]
                                         ValidRange: QBO: Min=1 Max=999
 
      * @xmlType element
@@ -154,8 +183,10 @@ class IPPTerm extends IPPIntuitEntity
     /**
      * @Definition
                                         Product: ALL
-                                        Description: Discount applies if paid before this day of month.
-                                        Business Rules: QBO: Required for the Create request when DueDays is not specified.
+                                        Description: Discount applies if
+                                        paid before this day of month.
+                                        Business Rules: QBO: Required
+                                        for the Create request when DueDays is not specified.
                                         ValidRange: QBO: Min=1 Max=31
 
      * @xmlType element
@@ -168,7 +199,8 @@ class IPPTerm extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description:- Internal use only: extension place holder for SalesTermEx
+                                Description:- Internal use only:
+                                extension place holder for SalesTermEx
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPTimeActivity.php
+++ b/src/Data/IPPTimeActivity.php
@@ -8,8 +8,10 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTimeActivity
  * @xmlDefinition The name of the person who performed the work.
                                 [b]QuickBooks Notes[/b][br /]
-                                Valid Vendor or Employee Name or Id is required for the create operation.[br /]
-                                Required for the create operation.
+                                Valid Vendor or Employee Name or Id
+                                is required for the create operation.[br /]
+                                Required for the
+                                create operation.
 
  */
 class IPPTimeActivity extends IPPIntuitEntity
@@ -24,22 +26,23 @@ class IPPTimeActivity extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTimeActivity', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTimeActivity', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTimeActivity', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTimeActivity', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition The timezone from where the time activity is entered, unused in QBO and QBW
+     * @Definition The timezone from where the time activity is
+                                entered, unused in QBO and QBW
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -49,6 +52,7 @@ class IPPTimeActivity extends IPPIntuitEntity
     public $TimeZone;
     /**
      * @Definition The date of the time activity.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -65,7 +69,8 @@ class IPPTimeActivity extends IPPIntuitEntity
      */
     public $NameOf;
     /**
-     * @Definition Specifies the employee whose time is being recorded.
+     * @Definition Specifies the employee whose time is being
+                                    recorded.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -74,7 +79,8 @@ class IPPTimeActivity extends IPPIntuitEntity
      */
     public $EmployeeRef;
     /**
-     * @Definition Specifies the vendor whose time is being recorded.
+     * @Definition Specifies the vendor whose time is being
+                                    recorded.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -83,7 +89,8 @@ class IPPTimeActivity extends IPPIntuitEntity
      */
     public $VendorRef;
     /**
-     * @Definition Specifies the Payee whose time is being recorded.
+     * @Definition Specifies the Payee whose time is being
+                                    recorded.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -103,6 +110,7 @@ class IPPTimeActivity extends IPPIntuitEntity
     public $CustomerRef;
     /**
      * @Definition  Represents Department Reference.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -112,7 +120,7 @@ class IPPTimeActivity extends IPPIntuitEntity
     public $DepartmentRef;
     /**
      * @Definition
-                                 [br /]
+                                [br /]
                                 Required for the create operation.
 
      * @xmlType element
@@ -131,8 +139,12 @@ class IPPTimeActivity extends IPPIntuitEntity
      */
     public $ClassRef;
     /**
-     * @Definition The payroll item determines how much the employee should be paid for doing the work specified by the Item Service Id.
-                                In order for the Time Activity data to be transferred to the employee payroll data, the Employee must have the property UseTimeEntry set.
+     * @Definition The payroll item determines how much the
+                                employee should be paid for doing the work specified by the Item
+                                Service Id.
+                                In order for the Time Activity data to be transferred
+                                to the employee payroll data, the Employee must have the
+                                property UseTimeEntry set.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -143,6 +155,7 @@ class IPPTimeActivity extends IPPIntuitEntity
     public $PayrollItemRef;
     /**
      * @Definition Billable status of the time recorded
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -151,7 +164,8 @@ class IPPTimeActivity extends IPPIntuitEntity
      */
     public $BillableStatus;
     /**
-     * @Definition True if the time recorded is both billable and taxable.
+     * @Definition True if the time recorded is both billable and
+                                taxable.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -160,9 +174,11 @@ class IPPTimeActivity extends IPPIntuitEntity
      */
     public $Taxable;
     /**
-     * @Definition Hourly bill rate of the employee or vendor for this time activity.
+     * @Definition Hourly bill rate of the employee or vendor for
+                                this time activity.
                                 [b]QuickBooks Notes[/b][br /]
-                                [i]Unsupported field.[/i]
+                                [i]Unsupported
+                                field.[/i]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -182,6 +198,7 @@ class IPPTimeActivity extends IPPIntuitEntity
     public $Hours;
     /**
      * @Definition Minutes worked; valid values are 0 - 59.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -190,7 +207,8 @@ class IPPTimeActivity extends IPPIntuitEntity
      */
     public $Minutes;
     /**
-     * @Definition Hours of break taken between start time and end time.
+     * @Definition Hours of break taken between start time and end
+                                time.
                                 [b]QuickBooks Notes[/b][br /]
                                 [i]Unsupported field.[/i]
 
@@ -202,7 +220,8 @@ class IPPTimeActivity extends IPPIntuitEntity
      */
     public $BreakHours;
     /**
-     * @Definition Minutes of break taken between start time and end time. Valid values are 0 - 59.
+     * @Definition Minutes of break taken between start time and
+                                end time. Valid values are 0 - 59.
                                 [b]QuickBooks Notes[/b][br /]
                                 [i]Unsupported field.[/i]
 
@@ -238,7 +257,8 @@ class IPPTimeActivity extends IPPIntuitEntity
      */
     public $EndTime;
     /**
-     * @Definition Description of work completed during time activity.
+     * @Definition Description of work completed during time
+                                activity.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -247,7 +267,8 @@ class IPPTimeActivity extends IPPIntuitEntity
      */
     public $Description;
     /**
-     * @Definition Internal use only: extension place holder for TimeActivity.
+     * @Definition Internal use only: extension place holder for
+                                TimeActivity.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPTimeActivityTypeEnum.php
+++ b/src/Data/IPPTimeActivityTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTimeActivityTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of time activity types.
+                Description: Enumeration of time
+                activity types.
 
  */
 class IPPTimeActivityTypeEnum
@@ -23,22 +24,22 @@ class IPPTimeActivityTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTimeActivityTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTimeActivityTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTimeActivityTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTimeActivityTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTimeActivityTypeEnum

--- a/src/Data/IPPTimeEntryUsedForPaychecksEnum.php
+++ b/src/Data/IPPTimeEntryUsedForPaychecksEnum.php
@@ -23,22 +23,22 @@ class IPPTimeEntryUsedForPaychecksEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTimeEntryUsedForPaychecksEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTimeEntryUsedForPaychecksEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTimeEntryUsedForPaychecksEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTimeEntryUsedForPaychecksEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTimeEntryUsedForPaychecksEnum

--- a/src/Data/IPPTimeTrackingPrefs.php
+++ b/src/Data/IPPTimeTrackingPrefs.php
@@ -7,6 +7,7 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPTimeTrackingPrefs
  * @var IPPTimeTrackingPrefs
  * @xmlDefinition Defines VendorAndPurchase Prefs details
+
  */
 class IPPTimeTrackingPrefs
 {
@@ -20,24 +21,25 @@ class IPPTimeTrackingPrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTimeTrackingPrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTimeTrackingPrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTimeTrackingPrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTimeTrackingPrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product:QBO
                         Enables services for time tracking
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -47,6 +49,7 @@ class IPPTimeTrackingPrefs
     public $UseServices;
     /**
      * @Definition Product:QBO Default TimeItem Id
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -58,6 +61,7 @@ class IPPTimeTrackingPrefs
      * @Definition
                         Product:QBO
                         Enables billing customers for time
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -69,6 +73,7 @@ class IPPTimeTrackingPrefs
      * @Definition
                         Product:QBO
                         Enables billing rate to all employees
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -80,6 +85,7 @@ class IPPTimeTrackingPrefs
      * @Definition
                         Product:All
                         Work week starting day
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -90,7 +96,9 @@ class IPPTimeTrackingPrefs
     /**
      * @Definition
                         Product:QBW
-                        Time Tracking preference from QB Desktop
+                        Time Tracking preference from QB
+                        Desktop
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -101,7 +109,9 @@ class IPPTimeTrackingPrefs
     /**
      * @Definition
                         Product:QBW
-                        MarkTimeEntriesBillable preference from QB Desktop
+                        MarkTimeEntriesBillable preference
+                        from QB Desktop
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -112,7 +122,9 @@ class IPPTimeTrackingPrefs
     /**
      * @Definition
                         Product:QBW
-                        MarkExpensesAsBillable preference from QB Desktop
+                        MarkExpensesAsBillable preference from
+                        QB Desktop
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPTransaction.php
+++ b/src/Data/IPPTransaction.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTransaction
  * @xmlDefinition
                 Product: ALL
-                Description: Transaction is the base class of all transactions.
+                Description: Transaction is the base
+                class of all transactions.
 
  */
 class IPPTransaction extends IPPIntuitEntity
@@ -23,25 +24,40 @@ class IPPTransaction extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTransaction', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTransaction', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTransaction', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTransaction', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL
-                                Description: QBO: Reference number for the transaction. If DocNumber is not provided, and the Custom Transaction Number is set to "Off", QBO assigns a document number using the next-in-sequence algorithm for Sales transactions. Otherwise the value will remaing null. Alternatively, you can also pass in "AUTO_GENERATE" in this field to force QBO to auto-sequence the document number for Invoices, Estimates and Sales Receipt.[br /]The maximum length for DocNumber is 21 characters. The default value is an empty String. Filter support not provided for Payment.
-                                Description: QBW: The primary document number for this transaction.  DocNumber is exposed to end users.[br /]If it is not provided, QuickBooks business logic will assign the document number using the "next in sequence" algorithm.[br /]Max. length is 11 characters for Payment, Bill, ItemReceipt and VendorCredit.  Max. length is 20 characters for other entities.
+                                Description: QBO: Reference number
+                                for the transaction. If DocNumber is not provided, and the
+                                Custom Transaction Number is set to "Off", QBO assigns a
+                                document number using the next-in-sequence algorithm for Sales
+                                transactions. Otherwise the value will remaing null.
+                                Alternatively, you can also pass in "AUTO_GENERATE" in this
+                                field to force QBO to auto-sequence the document number for
+                                Invoices, Estimates and Sales Receipt.[br /]The maximum length
+                                for DocNumber is 21 characters. The default value is an empty
+                                String. Filter support not provided for Payment.
+                                Description:
+                                QBW: The primary document number for this transaction. DocNumber
+                                is exposed to end users.[br /]If it is not provided, QuickBooks
+                                business logic will assign the document number using the "next
+                                in sequence" algorithm.[br /]Max. length is 11 characters for
+                                Payment, Bill, ItemReceipt and VendorCredit. Max. length is 20
+                                characters for other entities.
                                 Filterable: QBO
                                 InputType: ReadWrite
                                 ValidRange: QBW: max=11
@@ -57,10 +73,20 @@ class IPPTransaction extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: QBO: The date entered by the user when this transaction occurred. [br /]Often, it is the date when the transaction is created in the system. [br /]For "posting" transactions, this is the posting date that affects the financial statements. If the date is not supplied, the current date on the server is used.
-                                Description: QBW: The nominal, user entered, date of the transaction.  [br /]Often, but not required to be, the date the transaction was created in the system. [br /]For "posting" transactions, this is the posting date that affects financial statements.
+                                Description: QBO: The date entered
+                                by the user when this transaction occurred. [br /]Often, it is
+                                the date when the transaction is created in the system. [br
+                                /]For "posting" transactions, this is the posting date that
+                                affects the financial statements. If the date is not supplied,
+                                the current date on the server is used.
+                                Description: QBW: The
+                                nominal, user entered, date of the transaction. [br /]Often, but
+                                not required to be, the date the transaction was created in the
+                                system. [br /]For "posting" transactions, this is the posting
+                                date that affects financial statements.
                                 Filterable: ALL
-                                Sortable: ALL
+                                Sortable:
+                                ALL
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -73,7 +99,9 @@ class IPPTransaction extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Location of the transaction, as defined using location tracking in QuickBooks Online.
+                                Description: Location of the
+                                transaction, as defined using location tracking in QuickBooks
+                                Online.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -85,7 +113,9 @@ class IPPTransaction extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Reference to the Currency in which all amounts on the associated transaction are expressed.[br /]
+                                Description: Reference to the
+                                Currency in which all amounts on the associated transaction are
+                                expressed.[br /]
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -98,7 +128,13 @@ class IPPTransaction extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Currency exchange rate. Valid only if the company file is set up to use Multi-Currency feature. In QuickBooks, exchange rates are always recorded as the number of home currency units it takes to equal one foreign currency unit. The foreign unit is always 1 and the amount of home units that equal that 1 foreign unit is what QuickBooks uses as the exchange rate.
+                                Description: Currency exchange
+                                rate. Valid only if the company file is set up to use
+                                Multi-Currency feature. In QuickBooks, exchange rates are always
+                                recorded as the number of home currency units it takes to equal
+                                one foreign currency unit. The foreign unit is always 1 and the
+                                amount of home units that equal that 1 foreign unit is what
+                                QuickBooks uses as the exchange rate.
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -111,7 +147,9 @@ class IPPTransaction extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: User entered, organization-private note about the transaction. This note will not appear on the transaction records by default.
+                                Description: User entered,
+                                organization-private note about the transaction. This note will
+                                not appear on the transaction records by default.
                                 InputType: ReadWrite
 
      * @xmlType element
@@ -124,8 +162,17 @@ class IPPTransaction extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: QBW: The status of the transaction. Depending on the transaction type it may have different values.[br /]For Sales Transactions acceptable values are defined in PaymentStatusEnum. For Estimate, the values accepted are defined in EstimateStatusEnum.
-                                Description: QBO: The status of the transaction. Depending on the transaction type it may have different values.[br /]For Sales Transactions acceptable values are defined in PaymentStatusEnum. For Estimate, the values accepted are defined in QboEstimateStatusEnum.
+                                Description: QBW: The status of the
+                                transaction. Depending on the transaction type it may have
+                                different values.[br /]For Sales Transactions acceptable values
+                                are defined in PaymentStatusEnum. For Estimate, the values
+                                accepted are defined in EstimateStatusEnum.
+                                Description: QBO: The
+                                status of the transaction. Depending on the transaction type it
+                                may have different values.[br /]For Sales Transactions
+                                acceptable values are defined in PaymentStatusEnum. For
+                                Estimate, the values accepted are defined in
+                                QboEstimateStatusEnum.
                                 Filterable:QBW
 
      * @xmlType element
@@ -138,7 +185,8 @@ class IPPTransaction extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: A linked (related) transaction.  More than one transaction can be linked.
+                                Description: A linked (related)
+                                transaction. More than one transaction can be linked.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -151,9 +199,12 @@ class IPPTransaction extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: A line item of a transaction.
+                                Description: A line item of a
+                                transaction.
                                 Product: QBO
-                                Description: A line item of a transaction. QuickBooks Online does not support tax lines in the main transaction body, only in the TxnTaxDetail section.
+                                Description: A line item of a
+                                transaction. QuickBooks Online does not support tax lines in the
+                                main transaction body, only in the TxnTaxDetail section.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -166,7 +217,21 @@ class IPPTransaction extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: Details of taxes charged on the transaction as a whole. For US versions of QuickBooks, tax rates used in the detail section must not be used in any tax line appearing in the main transaction body. For international versions of QuickBooks, the TxnTaxDetail should provide the details of all taxes (sales or purchase) calculated for the transaction based on the tax codes referenced by the transaction. This can be calculated by QuickBooks business logic or you may supply it when adding a transaction. For US versions of QuickBooks you need only supply the tax code for the customer and the tax code (in the case of multiple rates) or tax rate (for a single rate) to apply for the transaction as a whole.[br]See [a href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01100_Global_Tax_Model"]Global Tax Model[/a].
+                                Description: Details of taxes
+                                charged on the transaction as a whole. For US versions of
+                                QuickBooks, tax rates used in the detail section must not be
+                                used in any tax line appearing in the main transaction body. For
+                                international versions of QuickBooks, the TxnTaxDetail should
+                                provide the details of all taxes (sales or purchase) calculated
+                                for the transaction based on the tax codes referenced by the
+                                transaction. This can be calculated by QuickBooks business logic
+                                or you may supply it when adding a transaction. For US versions
+                                of QuickBooks you need only supply the tax code for the customer
+                                and the tax code (in the case of multiple rates) or tax rate
+                                (for a single rate) to apply for the transaction as a
+                                whole.[br]See [a
+                                href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01100_Global_Tax_Model"]Global
+                                Tax Model[/a].
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -178,7 +243,9 @@ class IPPTransaction extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Originating source of the Transaction. Valid values are defined in TxnSourceEnum: QBMobile.
+                                Description: Originating source of
+                                the Transaction. Valid values are defined in TxnSourceEnum:
+                                QBMobile.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -189,8 +256,10 @@ class IPPTransaction extends IPPIntuitEntity
     public $TxnSource;
     /**
      * @Definition
-                                Description: refer TaxFormTypeEnum. Tax Form Type holds data related to Tax Information, values based on
-                                regional compliance laws. Applicable for IN Region and can be extended for other Regions.
+                                Description: refer TaxFormTypeEnum. Tax Form Type holds data related to Tax
+                                Information, values based on
+                                regional compliance laws. Applicable for IN Region and can be extended
+                                for other Regions.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -201,7 +270,9 @@ class IPPTransaction extends IPPIntuitEntity
     public $TaxFormType;
     /**
      * @Definition
-                                Description: Tax Form Num holds data related to Tax Information based on Regional compliance laws.This is applicable for IN region and can be extended to other regions in future.
+                                Description: Tax Form Num holds data related to Tax Information based on
+                                Regional compliance laws.This is applicable for IN region and
+                                can be extended to other regions in future.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -213,7 +284,10 @@ class IPPTransaction extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: Location of the purchase or sale transaction. The applicable values are those exposed through the TransactionLocationTypeEnum. This is currently applicable only for the FR region.
+                                Description: Location of the purchase or sale transaction. The applicable
+                                values are those exposed through the
+                                TransactionLocationTypeEnum. This is currently applicable only
+                                for the FR region.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPTransactionDeliveryInfo.php
+++ b/src/Data/IPPTransactionDeliveryInfo.php
@@ -23,20 +23,20 @@ class IPPTransactionDeliveryInfo
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTransactionDeliveryInfo', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTransactionDeliveryInfo', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTransactionDeliveryInfo', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTransactionDeliveryInfo', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: QBO

--- a/src/Data/IPPTransactionLocationTypeEnum.php
+++ b/src/Data/IPPTransactionLocationTypeEnum.php
@@ -23,22 +23,22 @@ class IPPTransactionLocationTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTransactionLocationTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTransactionLocationTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTransactionLocationTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTransactionLocationTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTransactionLocationTypeEnum

--- a/src/Data/IPPTransfer.php
+++ b/src/Data/IPPTransfer.php
@@ -6,7 +6,8 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType Transaction
  * @xmlName IPPTransfer
  * @var IPPTransfer
- * @xmlDefinition Financial transaction representing transfer of funds between accounts.
+ * @xmlDefinition Financial transaction representing transfer of
+                funds between accounts.
                 Non QB-writable.
 
  */
@@ -22,20 +23,20 @@ class IPPTransfer extends IPPTransaction
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTransfer', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTransfer', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTransfer', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTransfer', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition Must be a Balance Sheet account.
 
@@ -75,7 +76,8 @@ class IPPTransfer extends IPPTransaction
      */
     public $ClassRef;
     /**
-     * @Definition Internal use only: extension place holder for Transfer
+     * @Definition Internal use only: extension place holder for
+                                Transfer
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlName TransferEx

--- a/src/Data/IPPTxnSourceEnum.php
+++ b/src/Data/IPPTxnSourceEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTxnSourceEnum
  * @xmlDefinition
                 Product: QBO
-                Description: Enumeration of transaction source.
+                Description: Enumeration of transaction
+                source.
 
  */
 class IPPTxnSourceEnum
@@ -23,22 +24,22 @@ class IPPTxnSourceEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTxnSourceEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTxnSourceEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTxnSourceEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTxnSourceEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTxnSourceEnum

--- a/src/Data/IPPTxnTaxDetail.php
+++ b/src/Data/IPPTxnTaxDetail.php
@@ -8,7 +8,20 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTxnTaxDetail
  * @xmlDefinition
                 Product: ALL
-                Description: Details of taxes charged on the transaction as a whole. For US versions of QuickBooks, tax rates used in the detail section must not be used in any tax line appearing in the main transaction body. For international versions of QuickBooks, the TxnTaxDetail should provide the details of all taxes (sales or purchase) calculated for the transaction based on the tax codes referenced by the transaction. This can be calculated by QuickBooks business logic or you may supply it when adding a transaction. For US versions of QuickBooks you need only supply the tax code for the customer and the tax code (in the case of multiple rates) or tax rate (for a single rate) to apply for the transaction as a whole.[br]See [a href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01100_Global_Tax_Model"]Global Tax Model[/a].
+                Description: Details of taxes charged
+                on the transaction as a whole. For US versions of QuickBooks, tax
+                rates used in the detail section must not be used in any tax line
+                appearing in the main transaction body. For international versions
+                of QuickBooks, the TxnTaxDetail should provide the details of all
+                taxes (sales or purchase) calculated for the transaction based on
+                the tax codes referenced by the transaction. This can be calculated
+                by QuickBooks business logic or you may supply it when adding a
+                transaction. For US versions of QuickBooks you need only supply the
+                tax code for the customer and the tax code (in the case of multiple
+                rates) or tax rate (for a single rate) to apply for the transaction
+                as a whole.[br]See [a
+                href="http://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0060_Financial_Management_Services_(v3)/01100_Global_Tax_Model"]Global
+                Tax Model[/a].
 
  */
 class IPPTxnTaxDetail
@@ -23,26 +36,28 @@ class IPPTxnTaxDetail
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTxnTaxDetail', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTxnTaxDetail', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTxnTaxDetail', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTxnTaxDetail', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
-                            Product: QBW
-                            Description: Reference to the default tax code that applies to the transaction as a whole.
-                            In Quickbooks desktop, this maps to CustomerTaxCode in Invoice and VendorTaxCode in Bill.
-                            [span style="display: none"] I18n: US [/span]
+                        Product: QBW
+                        Description: Reference to the default tax code that applies to the transaction
+                        as a whole.
+                        In Quickbooks desktop, this maps to CustomerTaxCode in Invoice and
+                        VendorTaxCode in Bill.
+                        [span style="display: none"] I18n: US [/span]
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -54,8 +69,10 @@ class IPPTxnTaxDetail
     /**
      * @Definition
                         Product: All
-                        Description: Reference to the transaction tax code. For US editions only.
-                        Note that the US tax model can have just a single tax code for the entire transaction.
+                        Description: Reference to the
+                        transaction tax code. For US editions only.
+                        Note that the US tax model can have just a single tax code for the
+                        entire transaction.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -66,8 +83,9 @@ class IPPTxnTaxDetail
     public $TxnTaxCodeRef;
     /**
      * @Definition
-                            Product: ALL
-                            Description: Total tax calculated for the transaction, excluding any embedded tax lines.
+                        Product: ALL
+                        Description: Total tax calculated for the transaction, excluding any embedded
+                        tax lines.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -78,8 +96,8 @@ class IPPTxnTaxDetail
     public $TotalTax;
     /**
      * @Definition
-                            Product: ALL
-                            Description: This must be a Line whose LineDetailType is TaxLineDetail.
+                        Product: ALL
+                        Description: This must be a Line whose LineDetailType is TaxLineDetail.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPTxnTypeEnum.php
+++ b/src/Data/IPPTxnTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPTxnTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of transaction types.
+                Description: Enumeration of transaction
+                types.
 
  */
 class IPPTxnTypeEnum
@@ -23,22 +24,22 @@ class IPPTxnTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPTxnTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPTxnTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPTxnTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPTxnTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPTxnTypeEnum

--- a/src/Data/IPPUOM.php
+++ b/src/Data/IPPUOM.php
@@ -6,7 +6,10 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType IntuitEntity
  * @xmlName IPPUOM
  * @var IPPUOM
- * @xmlDefinition The UOM type defines the data used to represent a set of equivalent units and the conversion rates to other related units. It allows showing what quantities, prices, rates, and costs are based on.
+ * @xmlDefinition The UOM type defines the data used to represent a
+                set of equivalent units and the conversion rates to other related
+                units. It allows showing what quantities, prices, rates, and costs
+                are based on.
  */
 class IPPUOM extends IPPIntuitEntity
 {
@@ -20,23 +23,24 @@ class IPPUOM extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPUOM', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPUOM', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPUOM', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPUOM', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition User recognizable name of the Unit of Measure.[br /]
-                                 [br /]
+     * @Definition User recognizable name of the Unit of
+                                Measure.[br /]
+                                [br /]
                                 Required for the create operation. [br /]
                                 Max Length: 31
 
@@ -49,7 +53,7 @@ class IPPUOM extends IPPIntuitEntity
     public $Name;
     /**
      * @Definition Abbreviation of the Unit of Measure.[br /]
-                                 [br /]
+                                [br /]
                                 Required for the create operation. [br /]
                                 Max Length: 31
 
@@ -62,7 +66,7 @@ class IPPUOM extends IPPIntuitEntity
     public $Abbrv;
     /**
      * @Definition
-                                 [br /]
+                                [br /]
                                 Required for the create operation. [br /]
 
      * @xmlType element

--- a/src/Data/IPPUOMBaseTypeEnum.php
+++ b/src/Data/IPPUOMBaseTypeEnum.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPUOMBaseTypeEnum
  * @xmlDefinition
                 Product: ALL
-                Description: Enumeration of measurement types.
+                Description: Enumeration of measurement
+                types.
 
  */
 class IPPUOMBaseTypeEnum
@@ -23,22 +24,22 @@ class IPPUOMBaseTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPUOMBaseTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPUOMBaseTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPUOMBaseTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPUOMBaseTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPUOMBaseTypeEnum

--- a/src/Data/IPPUOMConvUnit.php
+++ b/src/Data/IPPUOMConvUnit.php
@@ -20,23 +20,24 @@ class IPPUOMConvUnit
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPUOMConvUnit', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPUOMConvUnit', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPUOMConvUnit', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPUOMConvUnit', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition User recognizable name of the Unit of Measure.[br /]
-                         [br /]
+     * @Definition User recognizable name of the Unit of Measure.[br
+                        /]
+                        [br /]
                         Required for the create operation. [br /]
                         Max Length: 31
 
@@ -49,7 +50,7 @@ class IPPUOMConvUnit
     public $Name;
     /**
      * @Definition Abbreviation of the Unit of Measure.[br /]
-                         [br /]
+                        [br /]
                         Required for the create operation. [br /]
                         Max Length: 31
 

--- a/src/Data/IPPUOMFeatureTypeEnum.php
+++ b/src/Data/IPPUOMFeatureTypeEnum.php
@@ -20,22 +20,22 @@ class IPPUOMFeatureTypeEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPUOMFeatureTypeEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPUOMFeatureTypeEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPUOMFeatureTypeEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPUOMFeatureTypeEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPUOMFeatureTypeEnum

--- a/src/Data/IPPUOMRef.php
+++ b/src/Data/IPPUOMRef.php
@@ -6,7 +6,10 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType
  * @xmlName IPPUOMRef
  * @var IPPUOMRef
- * @xmlDefinition When a unit of measure is referenced, it must include the name of the specific unit used as well as the unit of measure set in which that unit is defined. This entity captures that concept.
+ * @xmlDefinition When a unit of measure is referenced, it must
+                include the name of the specific unit used as well as the unit of
+                measure set in which that unit is defined. This entity captures that
+                concept.
  */
 class IPPUOMRef
 {
@@ -20,22 +23,23 @@ class IPPUOMRef
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPUOMRef', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPUOMRef', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPUOMRef', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPUOMRef', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition The name of the unit selected.  Examples: inch, foot, yard.
+     * @Definition The name of the unit selected. Examples: inch,
+                        foot, yard.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 1
@@ -44,7 +48,9 @@ class IPPUOMRef
      */
     public $Unit;
     /**
-     * @Definition A reference to the UOM entity that defines the set of related units from which the specified Unit is used.
+     * @Definition A reference to the UOM entity that defines the
+                        set of related units from which the specified Unit is used.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 1

--- a/src/Data/IPPUser.php
+++ b/src/Data/IPPUser.php
@@ -23,20 +23,20 @@ class IPPUser extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPUser', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPUser', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPUser', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPUser', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPUserAlert.php
+++ b/src/Data/IPPUserAlert.php
@@ -8,7 +8,8 @@ namespace QuickBooksOnline\API\Data;
  * @var IPPUserAlert
  * @xmlDefinition
                 Product: ALL
-                Description: A specific user alert to be notified to Quickbooks user, maps to a ToDo record in QuickBooks.
+                Description: A specific user alert to
+                be notified to Quickbooks user, maps to a ToDo record in QuickBooks.
 
  */
 class IPPUserAlert extends IPPIntuitEntity
@@ -23,24 +24,25 @@ class IPPUserAlert extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPUserAlert', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPUserAlert', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPUserAlert', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPUserAlert', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                                 Product: ALL
-                                Description: The actual content of the user alert
+                                Description: The actual content of
+                                the user alert
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -64,7 +66,8 @@ class IPPUserAlert extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBW
-                                Description: True if the user alert has been completed
+                                Description: True if the user alert
+                                has been completed
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -76,7 +79,8 @@ class IPPUserAlert extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: The type of the user alert
+                                Description: The type of the user
+                                alert
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -88,7 +92,8 @@ class IPPUserAlert extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: ALL
-                                Description: The date to remind the user of this user alert
+                                Description: The date to remind the
+                                user of this user alert
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -100,7 +105,8 @@ class IPPUserAlert extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: The date the user alert will expire
+                                Description: The date the user
+                                alert will expire
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -112,7 +118,8 @@ class IPPUserAlert extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: The date the user alert is due
+                                Description: The date the user
+                                alert is due
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -124,7 +131,8 @@ class IPPUserAlert extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: The URL that can be included in the user alert
+                                Description: The URL that can be
+                                included in the user alert
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -136,7 +144,8 @@ class IPPUserAlert extends IPPIntuitEntity
     /**
      * @Definition
                                 Product: QBO
-                                Description: The filter associated with the user alert
+                                Description: The filter associated
+                                with the user alert
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
@@ -146,7 +155,9 @@ class IPPUserAlert extends IPPIntuitEntity
      */
     public $Filter;
     /**
-     * @Definition Any other properties not covered in base is covered as name value pair, for detailed explanation look at the document
+     * @Definition Any other properties not covered in base is
+                                covered as name value pair, for detailed explanation look at the
+                                document
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -156,7 +167,8 @@ class IPPUserAlert extends IPPIntuitEntity
      */
     public $NameValue;
     /**
-     * @Definition Internal use only: extension place holder for user alert
+     * @Definition Internal use only: extension place holder for
+                                user alert
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0

--- a/src/Data/IPPVendor.php
+++ b/src/Data/IPPVendor.php
@@ -20,20 +20,20 @@ class IPPVendor extends IPPNameBase
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPVendor', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPVendor', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPVendor', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPVendor', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition  Name of the contact within the vendor. Used by QBD only
 
@@ -205,13 +205,9 @@ class IPPVendor extends IPPNameBase
      * @var float
      */
     public $Balance;
-
     /**
      * @Definition
-                                Product: ALL
-                                Description: The Bill Rate for that vendor.
-                                Filterable: QBW
-                                Sortable: QBW
+                                 BillRate can be set to specify this vendor's hourly billing rate.
 
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3

--- a/src/Data/IPPVendorAndPurchasesPrefs.php
+++ b/src/Data/IPPVendorAndPurchasesPrefs.php
@@ -7,6 +7,7 @@ namespace QuickBooksOnline\API\Data;
  * @xmlName IPPVendorAndPurchasesPrefs
  * @var IPPVendorAndPurchasesPrefs
  * @xmlDefinition Defines VendorAndPurchase Prefs details
+
  */
 class IPPVendorAndPurchasesPrefs
 {
@@ -20,24 +21,25 @@ class IPPVendorAndPurchasesPrefs
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPVendorAndPurchasesPrefs', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPVendorAndPurchasesPrefs', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPVendorAndPurchasesPrefs', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPVendorAndPurchasesPrefs', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product:All
                         Enables manage bills
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -49,6 +51,7 @@ class IPPVendorAndPurchasesPrefs
      * @Definition
                         Product:All
                         Enables tracking by customers
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -60,6 +63,7 @@ class IPPVendorAndPurchasesPrefs
      * @Definition
                         Product:All
                         Enable BillableExpense tracking
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -71,6 +75,7 @@ class IPPVendorAndPurchasesPrefs
      * @Definition
                         Product:All
                         Default Terms
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -81,7 +86,9 @@ class IPPVendorAndPurchasesPrefs
     /**
      * @Definition
                         Product:All
-                        Default markup rate used to calculate the markup amount on the transactions. To enter a markup rate of 8.5%, enter 8.5, not 0.085.
+                        Default markup rate used to calculate
+                        the markup amount on the transactions. To enter a markup rate of
+                        8.5%, enter 8.5, not 0.085.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -92,7 +99,9 @@ class IPPVendorAndPurchasesPrefs
     /**
      * @Definition
                         Product:All
-                        Default markup Account used to calculate the markup amount on the transactions.
+                        Default markup Account used to
+                        calculate the markup amount on the transactions.
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -104,6 +113,7 @@ class IPPVendorAndPurchasesPrefs
      * @Definition
                         Product:All
                         Apply automatic bill payment
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -115,6 +125,7 @@ class IPPVendorAndPurchasesPrefs
      * @Definition
                         Product:QBW
                         Defines the CustomField definitions
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -127,6 +138,7 @@ class IPPVendorAndPurchasesPrefs
      * @Definition
                         Product:All
                         Message to vendors
+
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -170,7 +182,8 @@ class IPPVendorAndPurchasesPrefs
     /**
      * @Definition
                         Cloud Max Length: 4000
-                        [b]QuickBooks Notes[/b][br /]
+                        [b]QuickBooks Notes[/b][br
+                        /]
                         Max Length: 31 or 159 (for a fully qualified name)
 
      * @xmlType element

--- a/src/Data/IPPVendorCredit.php
+++ b/src/Data/IPPVendorCredit.php
@@ -6,7 +6,9 @@ namespace QuickBooksOnline\API\Data;
  * @xmlType PurchaseByVendor
  * @xmlName IPPVendorCredit
  * @var IPPVendorCredit
- * @xmlDefinition Bill is an AP transaction representing a request-for-payment from a third party for goods/services rendered and/or received
+ * @xmlDefinition Bill is an AP transaction representing a
+                request-for-payment from a third party for goods/services rendered
+                and/or received
  */
 class IPPVendorCredit extends IPPPurchaseByVendor
 {
@@ -20,22 +22,23 @@ class IPPVendorCredit extends IPPPurchaseByVendor
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPVendorCredit', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPVendorCredit', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPVendorCredit', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPVendorCredit', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
-     * @Definition Internal use only: extension place holder for Bill extensible element  to qualify account.
+     * @Definition Internal use only: extension place holder for
+                                Bill extensible element to qualify account.
      * @xmlType element
      * @xmlNamespace http://schema.intuit.com/finance/v3
      * @xmlMinOccurs 0
@@ -43,4 +46,21 @@ class IPPVendorCredit extends IPPPurchaseByVendor
      * @var com\intuit\schema\finance\v3\IPPIntuitAnyType
      */
     public $VendorCreditEx;
+    /**
+     * @Definition
+                                Product: ALL
+                                Description: The unpaid amount of the bill. When paid-in-full, balance will
+                                be zero.
+                                [b]QuickBooks Notes[/b][br /]
+                                Non QB-writable.
+                                Filterable: QBW
+                                Sortable: QBW
+
+     * @xmlType element
+     * @xmlNamespace http://schema.intuit.com/finance/v3
+     * @xmlMinOccurs 0
+     * @xmlName Balance
+     * @var float
+     */
+    public $Balance;
 } // end class IPPVendorCredit

--- a/src/Data/IPPVendorType.php
+++ b/src/Data/IPPVendorType.php
@@ -20,20 +20,20 @@ class IPPVendorType extends IPPIntuitEntity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPVendorType', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPVendorType', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPVendorType', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPVendorType', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition User recognizable name for the Vendor Type.
                                 Length Restriction:

--- a/src/Data/IPPWarning.php
+++ b/src/Data/IPPWarning.php
@@ -12,26 +12,26 @@ class IPPWarning
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPWarning', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPWarning', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPWarning', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPWarning', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
 
     /**

--- a/src/Data/IPPWarnings.php
+++ b/src/Data/IPPWarnings.php
@@ -12,26 +12,26 @@ class IPPWarnings
 {
 
         /**
-        * Initializes this object, optionally with pre-defined property values
-        *
-        * Initializes this object and it's property members, using the dictionary
-        * of key/value pairs passed as an optional argument.
-        *
-        * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
-        * @param boolean $verbose specifies whether object should echo warnings
-        */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPWarnings', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPWarnings', $initPropName)) {
+         * Initializes this object, optionally with pre-defined property values
+         *
+         * Initializes this object and it's property members, using the dictionary
+         * of key/value pairs passed as an optional argument.
+         *
+         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+         * @param boolean    $verbose            specifies whether object should echo warnings
+         */
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPWarnings', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPWarnings', $initPropName)) {
                     $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
+            } else {
+                if ($verbose) {
                         echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
                 }
             }
         }
+    }
 
 
     /**

--- a/src/Data/IPPWebSiteAddress.php
+++ b/src/Data/IPPWebSiteAddress.php
@@ -23,20 +23,20 @@ class IPPWebSiteAddress
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPWebSiteAddress', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPWebSiteAddress', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPWebSiteAddress', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPWebSiteAddress', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
-
+    
     /**
      * @Definition
                         Product: ALL

--- a/src/Data/IPPWeekEnum.php
+++ b/src/Data/IPPWeekEnum.php
@@ -20,22 +20,22 @@ class IPPWeekEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPWeekEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPWeekEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPWeekEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPWeekEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPWeekEnum

--- a/src/Data/IPPcurrencyCode.php
+++ b/src/Data/IPPcurrencyCode.php
@@ -23,22 +23,22 @@ class IPPcurrencyCode
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPcurrencyCode', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPcurrencyCode', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPcurrencyCode', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPcurrencyCode', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPcurrencyCode

--- a/src/Data/IPPgender.php
+++ b/src/Data/IPPgender.php
@@ -23,22 +23,22 @@ class IPPgender
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPgender', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPgender', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPgender', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPgender', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPgender

--- a/src/Data/IPPid.php
+++ b/src/Data/IPPid.php
@@ -23,22 +23,22 @@ class IPPid
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPid', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPid', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPid', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPid', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPid

--- a/src/Data/IPPidDomainEnum.php
+++ b/src/Data/IPPidDomainEnum.php
@@ -23,22 +23,22 @@ class IPPidDomainEnum
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPidDomainEnum', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPidDomainEnum', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPidDomainEnum', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPidDomainEnum', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPidDomainEnum

--- a/src/Data/IPPobjectNameEnumType.php
+++ b/src/Data/IPPobjectNameEnumType.php
@@ -23,22 +23,22 @@ class IPPobjectNameEnumType
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPobjectNameEnumType', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPobjectNameEnumType', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPobjectNameEnumType', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPobjectNameEnumType', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPobjectNameEnumType

--- a/src/Data/IPPquantity.php
+++ b/src/Data/IPPquantity.php
@@ -23,22 +23,22 @@ class IPPquantity
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPquantity', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPquantity', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPquantity', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPquantity', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var float
          */
-        public $value;
+    public $value;
 } // end class IPPquantity

--- a/src/Data/IPPratio.php
+++ b/src/Data/IPPratio.php
@@ -23,22 +23,22 @@ class IPPratio
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPratio', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPratio', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPratio', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPratio', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var float
          */
-        public $value;
+    public $value;
 } // end class IPPratio

--- a/src/Data/IPPsyncToken.php
+++ b/src/Data/IPPsyncToken.php
@@ -23,22 +23,22 @@ class IPPsyncToken
         * @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
         * @param boolean $verbose specifies whether object should echo warnings
         */
-        public function __construct($keyValInitializers=array(), $verbose=false)
-        {
-            foreach ($keyValInitializers as $initPropName => $initPropVal) {
-                if (property_exists('IPPsyncToken', $initPropName)|| property_exists('QuickBooksOnline\API\Data\IPPsyncToken', $initPropName)) {
-                    $this->{$initPropName} = $initPropVal;
-                } else {
-                    if ($verbose) {
-                        echo "Property does not exist ($initPropName) in class (".get_class($this).")";
-                    }
+    public function __construct($keyValInitializers = array(), $verbose = false)
+    {
+        foreach ($keyValInitializers as $initPropName => $initPropVal) {
+            if (property_exists('IPPsyncToken', $initPropName) || property_exists('QuickBooksOnline\API\Data\IPPsyncToken', $initPropName)) {
+                $this->{$initPropName} = $initPropVal;
+            } else {
+                if ($verbose) {
+                    echo "Property does not exist ($initPropName) in class (".get_class($this).")";
                 }
             }
         }
+    }
 
         /**
          * @xmlType value
          * @var string
          */
-        public $value;
+    public $value;
 } // end class IPPsyncToken


### PR DESCRIPTION
Adds support for: `IPPCustomer.PrimaryTaxIdentifier`, `IPPCustomer.IsProject`, `IPPInvoice.invoiceStatus`, `IPPInvoice.callToAction`, `IPPItemLineDetail.TaxClassificationRef`, `IPPMarkupInfo.MarkUpIncomeAccountRef`, `IPPSalesFormsPrefs.SalesEmailCc`, `IPPSalesFormsPrefs.SalesEmailBcc`, `IPPSalesTransaction.FreeFormAddress`, `IPPSalesTransaction.TaxExemptionRef`, `IPPStatusInfo.*`, `IPPTaxCode.hidden`, `IPPTaxPrefs.HideTaxManagement`, `IPPTaxReturn.*`, `IPPTaxReturnStatusEnum.*`, `IPPVendorCredit.balance`


Maybe @dpfaffenbauer can run php-cs-fix on this or share what standard and options he used.