### PR TITLE
Update query param defined in ReportService.php to match QBO

### DIFF
--- a/src/ReportService/ReportService.php
+++ b/src/ReportService/ReportService.php
@@ -1070,7 +1070,7 @@ class ReportService
             array_push($uriParameterList, array("item", $this->getItem()));
         }
         if (!is_null($this->classid)) {
-            array_push($uriParameterList, array("class", $this->getClassid()));
+            array_push($uriParameterList, array("klass", $this->getClassid()));
         }
         if (!is_null($this->appaid)) {
             array_push($uriParameterList, array("appaid", $this->getAppaid()));


### PR DESCRIPTION
The 'class' uri parameter being set in the ReportService does not filter the report. Report filter only works when uri parameter is spelled 'klass' as seen in the uri used by the QBO web gui.