### PR TITLE
Add Detail to Exception level for better debugging

### DIFF
--- a/src/DataService/Batch.php
+++ b/src/DataService/Batch.php
@@ -383,7 +383,12 @@ class Batch
                     continue;
                 }
                 $error = new \stdClass();
-                $error->message = (string)$item->Message;
+                $detail = (string)$item->Detail;
+                if($detail) {
+                    $error->message = (string)$item->Message . ' - ' . $detail;                    
+                } else {
+                    $error->message = (string)$item->Message;                    
+                }
                 $error->code = null;
                 if ($item->attributes() instanceof \SimpleXMLElement
                             && isset($item->attributes()->code)) {


### PR DESCRIPTION
We see that in the API a lot of information is given in the detail level, this detail level is not given in the Exception (it is given in the Explorer). We have amended the library to add the detail.