### PR TITLE
Store IntuitResponse and allow public access

### DIFF
--- a/src/Core/HttpClients/SyncRestHandler.php
+++ b/src/Core/HttpClients/SyncRestHandler.php
@@ -158,7 +158,6 @@ class SyncRestHandler extends RestHandler
             $this->intuitResponse = $intuitResponse;
 
             return [$intuitResponse->getStatusCode(), $intuitResponse->getBody()];
-
         }
 
         throw new SdkException('OAuth Mode not supported.');


### PR DESCRIPTION
This PR is in reference to https://github.com/intuit/QuickBooks-V3-PHP-SDK/issues/184

Instead of storing headers explicitly, I think we should store the IntuitResponse itself and allow public access through a getter.