### PR TITLE
Fixed php7 'Parameter must be an array or an object that implements C…

### DIFF
--- a/src/QueryFilter/QueryMessage.php
+++ b/src/QueryFilter/QueryMessage.php
@@ -56,8 +56,8 @@ class QueryMessage
      */
     public function __construct()
     {
-        $projection = array();
-        $whereClause = array();
+        $this->projection = array();
+        $this->whereClause = array();
     }
 
     /**


### PR DESCRIPTION
Added fix for the QueryMessage.php class for php7 for following warning 
```Parameter must be an array or an object that implements Countable```