### PR TITLE
Clean whitespace & labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Create, Update, Read, and Delete Examples: https://github.com/IntuitDeveloper/Sa
 
 **Help:** [Support](https://developer.intuit.com/help)<br/>
 **Documentation:** [Documentation](https://intuit.github.io/QuickBooks-V3-PHP-SDK/)<br/>
-**Continuous Integration:**![Build status](https://travis-ci.org/intuit/QuickBooks-V3-PHP-SDK.svg?branch=master)
-[![Latest Stable Version](https://poser.pugx.org/quickbooks/v3-php-sdk/v/stable)](https://packagist.org/packages/quickbooks/v3-php-sdk)<br/>
+**Continuous Integration:** ![Build status](https://travis-ci.org/intuit/QuickBooks-V3-PHP-SDK.svg?branch=master)<br />
+**Latest Stable Version:** [![Latest Stable Version](https://poser.pugx.org/quickbooks/v3-php-sdk/v/stable)](https://packagist.org/packages/quickbooks/v3-php-sdk)<br/>
 **License:** [![License](https://poser.pugx.org/quickbooks/v3-php-sdk/license)](https://packagist.org/packages/quickbooks/v3-php-sdk)
 
 [ss1]: https://help.developer.intuit.com/s/SDKFeedback?cid=1105

--- a/src/Core/CoreConstants.php
+++ b/src/Core/CoreConstants.php
@@ -6,7 +6,7 @@ namespace QuickBooksOnline\API\Core;
  */
 class CoreConstants
 {
-    //Set the default minor version to 23
+    //Set the default minor version
     const DEFAULT_SDK_MINOR_VERSION = "36";
     const DEFAULT_LOGGINGLOCATION = "/tmp/IdsLogs";
 


### PR DESCRIPTION
I did a couple of housekeeping items:

1. Removed the reference to the exact minor version that we're on in `CoreConstants.php`. That way, no one has to update the version in 2 places.

2. In the README, fix labeling and whitespace to make the links and badges appear uniformly.