### PR TITLE
Avoid undefined variable

### DIFF
--- a/src/DataService/DataService.php
+++ b/src/DataService/DataService.php
@@ -989,9 +989,9 @@ class DataService
                 $responseXmlObj = simplexml_load_string($responseBody);
                 if ($responseXmlObj && $responseXmlObj->QueryResponse) {
                     $tmpXML = $responseXmlObj->QueryResponse->asXML();
+                    $parsedResponseBody = $this->responseSerializer->Deserialize($tmpXML, false);
+                    $this->serviceContext->IppConfiguration->Logger->CustomLogger->Log(TraceLevel::Info, $parsedResponseBody);
                 }
-                $parsedResponseBody = $this->responseSerializer->Deserialize($tmpXML, false);
-                $this->serviceContext->IppConfiguration->Logger->CustomLogger->Log(TraceLevel::Info, $parsedResponseBody);
 
             } catch (\Exception $e) {
                 throw new \Exception("Exception appears in converting Response to XML.");


### PR DESCRIPTION
I believe this was the original intent of 3a9ce07be5dc73a6ae816e880a384186335f043a based on the indentation there and the fact that `$tmpXML` is of no use if not defined.