### PR TITLE
adding missing use statement, removing invalid if condition check

### DIFF
--- a/src/Core/Http/Serialization/XmlObjectSerializer.php
+++ b/src/Core/Http/Serialization/XmlObjectSerializer.php
@@ -7,6 +7,7 @@ use QuickBooksOnline\API\Data\IPPIntuitEntity;
 use QuickBooksOnline\API\XSD2PHP\src\com\mikebevz\xsd2php\Php2Xml;
 use QuickBooksOnline\API\XSD2PHP\src\com\mikebevz\xsd2php\Bind;
 use QuickBooksOnline\API\Diagnostics\Logger;
+use QuickBooksOnline\API\Diagnostics\TraceLevel;
 
 /**
  * Xml Serialize(r) to serialize and de serialize.

--- a/src/DataService/DataService.php
+++ b/src/DataService/DataService.php
@@ -1668,7 +1668,7 @@ class DataService
      * @return String Id
      */
     private function getIDString($id){
-        if($id instanceof IPPid || $id instanceof QuickBooksOnline\API\Data\IPPid){
+        if($id instanceof IPPid){
             return (String)$id->value;
         }else{
             return (String)$id;


### PR DESCRIPTION
Noticed in my editor that there were some errors in these two files related to namespaces.

In `XmlObjectSerializer` there was no `use` statement for the `QuickBooksOnline\API\Diagnostics\TraceLevel` class, but it's being used as `TraceLevel` in the file, which doesn't exist on the `QuickBooksOnline\API\Core\Http\Serialization` namespace that's defined at the top of the file.

For `DataService` there is an `instanceof` check on a non-global class name that doesn't exist in the namespace defined on the file.  It's actually a redundant check though, as `IPPid` is defined in a `use` statement at the top of the file as `use QuickBooksOnline\API\Data\IPPid;`. 