### PR TITLE
Revert change "Set default use SSL to false"

### DIFF
--- a/src/Core/HttpClients/SyncRestHandler.php
+++ b/src/Core/HttpClients/SyncRestHandler.php
@@ -203,7 +203,7 @@ class SyncRestHandler extends RestHandler
              throw new SdkException("IPP or other Call is not supported in OAuth2 Mode.");
         }
 
-        $intuitResponse = $this->httpClientInterface->makeAPICall($requestUri, $HttpMethod, $httpHeaders,  $requestBody, null, false);
+        $intuitResponse = $this->httpClientInterface->makeAPICall($requestUri, $HttpMethod, $httpHeaders,  $requestBody, null, true);
         $faultHandler = $intuitResponse->getFaultHandler();
         $this->LogAPIResponseToLog($intuitResponse->getBody(), $requestUri, $intuitResponse->getHeaders());
 


### PR DESCRIPTION
Reverts the change to disable SSL verification in QBO API call interface.

See https://github.com/intuit/QuickBooks-V3-PHP-SDK/commit/670e0201518fbaad1e9339d76ab30eaf17078e62