### PR TITLE
Update travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
 - 7.1
 - 7.2
 before_install:
-- composer self-update
+- if [[ $TRAVIS_PHP_VERSION == 7.1* ]]; then composer require phpunit/phpunit:~7.5.9; else composer self-update;fi
 before_script:
 - composer install
 script:


### PR DESCRIPTION
Travis auto load PHPUnit version that is not compatible with PHP7.1.
Force travis to load a lower version.