### PR TITLE
Update (XmlObjectSerializer): Only allow namespaced classes to be generated from XML elements

### DIFF
--- a/src/Core/Http/Serialization/XmlObjectSerializer.php
+++ b/src/Core/Http/Serialization/XmlObjectSerializer.php
@@ -83,9 +83,7 @@ class XmlObjectSerializer extends IEntitySerializer
     private static function PhpObjFromXml($className, $xmlStr)
     {
         $className = trim($className);
-        if (class_exists($className, CoreConstants::USE_AUTOLOADER)) {
-            $phpObj = new $className;
-        } elseif (class_exists(CoreConstants::NAMEPSACE_DATA_PREFIX . $className, CoreConstants::USE_AUTOLOADER)) {
+        if (class_exists(CoreConstants::NAMEPSACE_DATA_PREFIX . $className, CoreConstants::USE_AUTOLOADER)) {
             $className = CoreConstants::NAMEPSACE_DATA_PREFIX . $className;
             $phpObj = new $className;
         } else {


### PR DESCRIPTION
Force object to use the namespaced class when creating an object from an xml element and do not create an object from a class that is not within the namespace. 

From issue https://github.com/intuit/QuickBooks-V3-PHP-SDK/issues/274. This ensures that conflicting libraries do not accidentally get loaded before the libraries from this SDK