### PR TITLE
Several improvements for Batch 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 composer.phar
 /nbproject
 .DS_Store
-.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 /nbproject
 .DS_Store
+.idea/*

--- a/src/Core/HttpClients/BaseCurl.php
+++ b/src/Core/HttpClients/BaseCurl.php
@@ -101,26 +101,6 @@ class BaseCurl{
   }
 
   /**
-   * Set the curl TLS Version and check if TLS 1.2 is supported
-   * @return int TLSversion
-   */
-  public function versionOfTLS(){
-      $tlsVersion = "";
-      $curl = curl_init();
-      curl_setopt($curl, CURLOPT_URL, "https://www.howsmyssl.com/a/check");
-      curl_setopt($curl, CURLOPT_SSLVERSION, 6);
-      curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-      $curlVersionResponse = curl_exec($curl);
-      if($curlVersionResponse === false){
-         throw new SdkException("Error in checking cURL version for TLS 1.2. Error Num:[" . curl_errno($curl) . "] Error message:[" . curl_error($curl) . "]");
-      }else{
-         $tlsVersion = json_decode($curlVersionResponse)->tls_version;
-      }
-      curl_close($curl);
-      return $tlsVersion;
-  }
-
-  /**
    * Get info from a curl reference from the type
    * Mainly used after execute()
    * use $type=CURLINFO_HEADER_OUT for header, and $type=CURLINFO_HTTP_CODE for http_code

--- a/src/Core/HttpClients/CurlHttpClient.php
+++ b/src/Core/HttpClients/CurlHttpClient.php
@@ -54,6 +54,10 @@ class CurlHttpClient implements HttpClientInterface{
      * @inheritdoc
      */
     public function prepareRequest($url, $method, array $headers, $body, $timeOut, $verifySSL){
+        if (defined('QUICKBOOKS_API_TIMEOUT')) {
+            // if the timeout constant is set, use it for the timeout
+            $timeOut = (int)QUICKBOOKS_API_TIMEOUT;
+        }
         //Set basic Curl Info
         $curl_opt = [
             CURLOPT_URL => $url,
@@ -62,8 +66,8 @@ class CurlHttpClient implements HttpClientInterface{
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HTTPHEADER => $this->getHeaders($headers),
             //10 seconds is allowed to make the connection to the server
-            CURLOPT_CONNECTTIMEOUT => isset($timeOut) ? $timeOut : 100,
-            CURLOPT_TIMEOUT => isset($timeOut) ? $timeOut : 100,
+            CURLOPT_CONNECTTIMEOUT => isset($timeOut) ? $timeOut : 15,
+            CURLOPT_TIMEOUT => isset($timeOut) ? $timeOut : 15,
             CURLOPT_RETURNTRANSFER => true,
             //When CURLOPT_HEADER is set to 0 the only effect is that header info from the response is excluded from the output.
             //So if you don't need it that's a few less KBs that curl will return to you.

--- a/src/Core/HttpClients/CurlHttpClient.php
+++ b/src/Core/HttpClients/CurlHttpClient.php
@@ -62,7 +62,7 @@ class CurlHttpClient implements HttpClientInterface{
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HTTPHEADER => $this->getHeaders($headers),
             //10 seconds is allowed to make the connection to the server
-            CURLOPT_CONNECTTIMEOUT => 10,
+            CURLOPT_CONNECTTIMEOUT => isset($timeOut) ? $timeOut : 100,
             CURLOPT_TIMEOUT => isset($timeOut) ? $timeOut : 100,
             CURLOPT_RETURNTRANSFER => true,
             //When CURLOPT_HEADER is set to 0 the only effect is that header info from the response is excluded from the output.

--- a/src/Core/HttpClients/SyncRestHandler.php
+++ b/src/Core/HttpClients/SyncRestHandler.php
@@ -57,12 +57,21 @@ class SyncRestHandler extends RestHandler
         $this->httpClientInterface = isset($client) ? $client : new CurlHttpClient();
     }
 
+    /**
+     * Gets the http client interface
+     * @return CurlHttpClient|HttpClientInterface
+     */
+    public function getHttpClientInterface()
+    {
+        return $this->httpClientInterface;
+    }
+
    /**
     * Update the Service Context of the request.
-    *
-    * @param ServiceContext  $newServiceContext      The new service context that will be used for the request
+    * @param ServiceContext $newServiceContext The new service context that will be used for the request
     */
-    public function updateContext($newServiceContext){
+    public function updateContext($newServiceContext)
+    {
         if(isset($newServiceContext) && $newServiceContext instanceof ServiceContext){
             $this->context = $newServiceContext;
         }else{

--- a/src/DataService/Batch.php
+++ b/src/DataService/Batch.php
@@ -197,8 +197,9 @@ class Batch
      * @param IEntity entity entitiy for the batch operation.
      * @param string id Unique batchitem id
      * @param OperationEnum operation operation to be performed for the entity.
+     * @param string optionsdata to send with this specific batch item (example - allowduplicatedocnumber for invoices)
      */
-     public function AddEntity($entity, $id, $operation)
+     public function AddEntity($entity, $id, $operation, $optionsData = null)
      {
          if (!$entity) {
              $exception = new IdsException('StringParameterNullOrEmpty: entity');
@@ -227,6 +228,9 @@ class Batch
          $batchItem->bId = $id;
          $batchItem->operation = $operation;
          $batchItem->operationSpecified = true;
+         if ($optionsData !== null) {
+             $batchItem->optionsData = $optionsData;
+         }
 
          $this->batchRequests[] = $batchItem;
      }
@@ -302,6 +306,9 @@ class Batch
       try {
           // Get literal XML representation of IntuitBatchRequest into a DOMDocument
           $httpsPostBodyPreProcessed = XmlObjectSerializer::getPostXmlFromArbitraryEntity($intuitBatchRequest, $urlResource);
+
+          echo $httpsPostBodyPreProcessed;
+
           $doc = new \DOMDocument();
           $domObj = $doc->loadXML($httpsPostBodyPreProcessed);
           $xpath = new \DOMXPath($doc);

--- a/src/DataService/Batch.php
+++ b/src/DataService/Batch.php
@@ -92,12 +92,27 @@ class Batch
     private $isThrowExceptionOnError = false;
 
     /**
+     * Enable debug mode to get more information inside the exception like intuit-tid
+     * @var boolean
+     */
+    private $debugMode = false;
+
+    /**
     * Get the error from last request
     * @return FaultHandler
     */
     public function getLastError()
     {
         return $this->lastError;
+    }
+
+    /**
+     * Set the debug mode
+     * @param $mode
+     */
+    public function setDebug($mode)
+    {
+        $this->debugMode = $mode;
     }
 
     /**
@@ -527,6 +542,9 @@ class Batch
         }
 
         $firstChildName = (string)$firstChild->getName();
+
+        var_dump($this->debugMode);
+        die();
 
         switch ($firstChildName) {
               //For batch query result

--- a/src/DataService/Batch.php
+++ b/src/DataService/Batch.php
@@ -307,8 +307,6 @@ class Batch
           // Get literal XML representation of IntuitBatchRequest into a DOMDocument
           $httpsPostBodyPreProcessed = XmlObjectSerializer::getPostXmlFromArbitraryEntity($intuitBatchRequest, $urlResource);
 
-          echo $httpsPostBodyPreProcessed;
-
           $doc = new \DOMDocument();
           $domObj = $doc->loadXML($httpsPostBodyPreProcessed);
           $xpath = new \DOMXPath($doc);

--- a/src/DataService/Batch.php
+++ b/src/DataService/Batch.php
@@ -543,9 +543,6 @@ class Batch
 
         $firstChildName = (string)$firstChild->getName();
 
-        var_dump($this->debugMode);
-        die();
-
         switch ($firstChildName) {
               //For batch query result
               case "QueryResponse":
@@ -562,6 +559,16 @@ class Batch
               case "Fault":
                   $result->responseType = UtilityConstants::Exception;
                   $idsException = $this->IterateFaultAndPrepareException($firstChild);
+                  if($this->debugMode) {
+                      $interface = $this->restHandler->getHttpClientInterface();
+                      $responseInterface = $interface->getLastResponse();
+                      $debugInfo = [
+                          'intuit_tid' => $responseInterface->getIntuitTid(),
+                          'body' => $responseInterface->getBody(),
+                          'headers' => $responseInterface->getHeaders(),
+                      ];
+                      $idsException->setDebug($debugInfo);
+                  }
                   $result->exception = $idsException;
                   break;
               //For batch Entity Result

--- a/src/Exception/IdsException.php
+++ b/src/Exception/IdsException.php
@@ -8,6 +8,12 @@ namespace QuickBooksOnline\API\Exception;
 class IdsException extends \Exception
 {
     /**
+     * Debug information like intuit tid etc
+     * @var array
+     */
+    private $debug = [];
+
+    /**
      * Initializes a new instance of the IdsException class.
      *
      * @param string $message string-based exception description
@@ -16,6 +22,24 @@ class IdsException extends \Exception
     public function __construct($message, $code = 0)
     {
         parent::__construct($message, $code);
+    }
+
+    /**
+     * Set the debug info
+     * @param $info
+     */
+    public function setDebug($info)
+    {
+        $this->debug = $info;
+    }
+
+    /**
+     * Returns the specific Intuit debug information for this call
+     * @param $info
+     */
+    public function getDebug()
+    {
+        return $this->debug;
     }
 
     /**


### PR DESCRIPTION
Made several improvements here to sync up with our repo:

1. Removed versionOfTLS() since it was not used anymore - it was already removed in master on your end - this caused issues when doing a lot of requests, howmyssl.com could not handle volume
2. Aligned timeouts, sometimes sandboxes are somewhat slower and the the 10 seconds does not cut it, so I've aligned them to be 100 seconds if they are not actively passed into the function
3. Added the $optionsdata when adding a entity to a batch via AddEntity, this way you can pass in several parameters like allowduplicatedocnum for journals - it was already available in the underlying class just added the var for it

Lastly I've added debug to Batch, our tool is heavily reliant on Batch and we often need to provide Intuit with Intuit TID's, which is quite straightforward if you are using the single entities but wasn't available in batch.

**Usage** 

First create a batch like usual, but set the debug flag to true (default is off):

    $batch = $connection->CreateNewBatch();
    $batch->setDebug(true);

When adding something to the batch (entity wise) you can also specify the fourth parameter now:

    $batch->AddEntity($entity, $reference_id, 'create', 'allowduplicatedocnumber');

This will pass the option string into the batch item. 

When the response for the whole batch comes back, you can ask for success and get the error from the batch (via $batch->intuitBatchItemResponses) and for instance loop over them in a variable called $response.

     if (!$response->isSuccess()) {
          $result_error = $response->getError();
          $debug = $result_error->getDebug();
    }

$debug is an array with the following parameters:

* intuit_tid = The Intuit TID allowing Intuit to easily find the request / response on their side
* body = The body posted to Quickbooks, which can be helpful to find issues
* headers = The response headers for the request
  
Let me know if you have questions.
