### PR TITLE
Added order_by to list of report options.

### DIFF
--- a/src/ReportService/ReportService.php
+++ b/src/ReportService/ReportService.php
@@ -79,6 +79,7 @@ class ReportService
     private $columns = null;
     private $sort_by = null;
     private $sort_order = null;
+    private $order_by = null;
     private $group_by = null;
     private $createdate_macro = null;
     private $end_createdate = null;
@@ -659,6 +660,25 @@ class ReportService
     /**
      * @return null
      */
+    public function getOrderBy()
+    {
+        return $this->order_by;
+    }
+
+    /**
+     * @param null $order_by
+     *
+     * @return $this
+     */
+    public function setOrderBy($order_by)
+    {
+        $this->order_by = $order_by;
+        return $this;
+    }
+
+    /**
+     * @return null
+     */
     public function getGroupBy()
     {
         return $this->group_by;
@@ -1130,6 +1150,9 @@ class ReportService
         }
         if (!is_null($this->sort_order)) {
             array_push($uriParameterList, array("sort_order", $this->getSortOrder()));
+        }
+        if (!is_null($this->order_by)) {
+            array_push($uriParameterList, array("order_by", $this->getOrderBy()));
         }
         if (!is_null($this->group_by)) {
             array_push($uriParameterList, array("group_by", $this->getGroupBy()));


### PR DESCRIPTION
I found out there is a bug in the v3 API for report service which throws an API error for sort_by modifier. However, using 'order_by' works in this case. sort_order works fine along with order_by, so I did not need to add anything else. I left sort_by and just added the order_by modifier to the reportService. Hope this helps someone else as well.