### PR TITLE
exclude docs and test dirs in the composer archive config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,14 @@
     "suggest": {
         "ext-curl": "Uses Curl to make HTTP Requests",
         "guzzlehttp/guzzle": "Uses Guzzle to make HTTP Requests"
+    },
+    "archive": {
+        "exclude": [
+            "/docs",
+            "/src/Utility.Test",
+            "/src/XSD2PHP/docs",
+            "/src/XSD2PHP/test",
+            "/test"
+        ]
     }
 }


### PR DESCRIPTION
This change adds a list of excluded directories to the `archive` section of composer.json, which will prevent those directories from being installed into the vendor directory when installing this SDK as a composer dependency.

This significantly reduces the size of the installed dependency (tested by looking at the resulting .tar file created by the `composer archive` command):

Before: 24,130,560 bytes
After: 6,334,976 bytes

This change, in part, came about as an attempt to remove a file that was causing [composer-require-checker](https://github.com/maglnet/ComposerRequireChecker) to fail when ran on our own project, due to `Parent` being a reserved classname in PHP7. This file was causing it to fail:  src/XSD2PHP/test/data/expected/Xsd2Php/MavenTests/bindings/org/apache/maven/POM/_4_0_0/Parent.php