### PR TITLE
FATAL ERROR FIX

### DIFF
--- a/src/Core/Http/Serialization/XmlObjectSerializer.php
+++ b/src/Core/Http/Serialization/XmlObjectSerializer.php
@@ -182,9 +182,9 @@ class XmlObjectSerializer extends IEntitySerializer
     public function __construct($idsLogger = null)
     {
         if ($idsLogger) {
-            $this->IDSLogger = $idsLogger;
+            self::IDSLogger = $idsLogger;
         } else {
-            $this->IDSLogger = null;
+            self::IDSLogger = null;
         } // new TraceLogger();
     }
 


### PR DESCRIPTION
Need to refer to all reference to a variable with static formatting when you change them to static