### PR TITLE
Handle faulty response when the response type is text/xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 /nbproject
 .DS_Store
+.idea

--- a/src/Core/HttpClients/IntuitResponse.php
+++ b/src/Core/HttpClients/IntuitResponse.php
@@ -144,7 +144,8 @@ class IntuitResponse{
         //A standard message for now.
         //TO DO: Wait V3 Team to provide different message for different response.
         $this->faultHandler->setHelpMsg("Invalid auth/bad request (got a " . $httpResponseCode . ", expected HTTP/1.1 20X or a redirect)");
-        if($this->getResponseContentType() != null && strcasecmp($this->getResponseContentType(), CoreConstants::CONTENTTYPE_APPLICATIONXML) == 0){
+        if($this->getResponseContentType() != null && (strcasecmp($this->getResponseContentType(), CoreConstants::CONTENTTYPE_APPLICATIONXML) == 0 ||
+                strcasecmp($this->getResponseContentType(), CoreConstants::CONTENTTYPE_TEXTXML) == 0)){
             $this->faultHandler->parseResponse($body);
         }
      }else{


### PR DESCRIPTION
`Overview`:
In IntuitResponse.php, a fault response isn't parsed unless the content-type is "application/xml". However, for a 401 response, the content type is "text/xml." This results in the response not being parsed.

It seems like either the check should be updated in IntuitResponse.php::147, or responses should be sent using the content-type of "application/xml".

Fix provided for #351 

Changes:
- `setFaultHandler()` to parse faulty response when the `content-type`:`text/xml`