### PR TITLE
Renaming file for IPPWrapper class to make it PSR4 and Composer 2 compatible

### DIFF
--- a/src/Data/IPPWrapper.php
+++ b/src/Data/IPPWrapper.php
@@ -4,21 +4,21 @@ namespace QuickBooksOnline\API\Data;
 /**
  * @xmlNamespace http://schema.intuit.com/finance/v3
  * @xmlType string
- * @xmlName IPP
- * @var IPP
+ * @xmlName IPPWrapper
+ * @var IPPWrapper
  */
 class IPPWrapper
 	{
 
-		/**                                                                       
-		* Initializes this object, optionally with pre-defined property values    
-		*                                                                         
+		/**
+		* Initializes this object, optionally with pre-defined property values
+		*
 		* Initializes this object and it's property members, using the dictionary
-		* of key/value pairs passed as an optional argument.                      
-		*                                                                         
-		* @param dictionary $keyValInitializers key/value pairs to be populated into object's properties 
-		* @param boolean $verbose specifies whether object should echo warnings   
-		*/                                                                        
+		* of key/value pairs passed as an optional argument.
+		*
+		* @param dictionary $keyValInitializers key/value pairs to be populated into object's properties
+		* @param boolean $verbose specifies whether object should echo warnings
+		*/
 		public function __construct($keyValInitializers=array(), $verbose=FALSE)
 		{
 			foreach($keyValInitializers as $initPropName => $initPropVal)


### PR DESCRIPTION
This fixes #341 and #329 and should replace the fix in #361 as that change erroneously changes the namespace of the `IPPWrapper` class, but that's not necessary for this fix as all of the IPP SDK classes live in the `QuickBooksOnline\API` namespace as that's how they're autoloaded in `composer.json`.

I didn't see any cases where this class was being explicitly required by filename, but anybody doing that (and not using composer's autoloading) might have an issue loading this class.

A dummy `IPP.php` file that just requires `IPPWrapper.php` could be put in place to combat this situation, if that seems reasonable.