### PR TITLE
Remove optional parameter fileName, 

### DIFF
--- a/src/DataService/DataService.php
+++ b/src/DataService/DataService.php
@@ -1667,7 +1667,7 @@ class DataService
      * @param string $fileName
      * @return mixed full path with filename or open handler
      */
-    protected function processDownloadedContent(ContentWriter $writer, $responseCode, $fileName = null, $dir)
+    protected function processDownloadedContent(ContentWriter $writer, $responseCode, $fileName, $dir)
     {
         $writer->setPrefix($this->getPrefixFromSettings());
         try {


### PR DESCRIPTION
php 8 requires optional params to be before required parameters. This function is failing after I upgraded to php 8 today.