### PR TITLE
PHP8 - Update DataService to fix Required parameter $dir follows opti…

### DIFF
--- a/src/DataService/DataService.php
+++ b/src/DataService/DataService.php
@@ -948,11 +948,8 @@ class DataService
             return $responseBody;
         } else {
             $this->lastError = false;
-
-            if($raw)
-                return $responseBody;
-
-            return $this->processDownloadedContent(new ContentWriter($responseBody), $responseCode, $this->getExportFileNameForPDF($entity, "pdf"), $dir);
+            
+            return $this->processDownloadedContent(new ContentWriter($responseBody), $responseCode, $dir, $this->getExportFileNameForPDF($entity, "pdf"));
         }
     }
 
@@ -1667,7 +1664,7 @@ class DataService
      * @param string $fileName
      * @return mixed full path with filename or open handler
      */
-    protected function processDownloadedContent(ContentWriter $writer, $responseCode, $fileName = null, $dir)
+    protected function processDownloadedContent(ContentWriter $writer, $responseCode, $dir, $fileName = null)
     {
         $writer->setPrefix($this->getPrefixFromSettings());
         try {


### PR DESCRIPTION
DataService update to fix 2 errors in DownloadPDF method.

**Issue 1** (https://github.com/intuit/QuickBooks-V3-PHP-SDK/issues/383)
Required parameter $dir follows optional parameter $fileName
https://php.watch/versions/8.0/deprecate-required-param-after-optional

**Issue 2** (https://github.com/intuit/QuickBooks-V3-PHP-SDK/issues/381)
$raw is undefined 

Notice: Undefined variable: raw at ./vendor/quickbooks/v3-php-sdk/src/DataService/DataService.php:952
$raw is not referenced anywhere in method.

