### PR TITLE
Upload Method Expects base64 Encoded Data

### DIFF
--- a/src/_Samples/UploadAttachment.php
+++ b/src/_Samples/UploadAttachment.php
@@ -128,7 +128,7 @@ $objAttachable->Category = 'Image';
 $objAttachable->Tag = 'Tag_' . $randId;
 
 // Upload the attachment to the Bill
-$resultObj = $dataService->Upload(base64_decode($imageBase64[$sendMimeType]),
+$resultObj = $dataService->Upload($imageBase64[$sendMimeType],
                                   $objAttachable->FileName,
                                   $sendMimeType,
                                   $objAttachable);


### PR DESCRIPTION
Just wasted two hours trying to figure out why my attachments were all corrupted in the QBO.
 
The `Upload` Method expects base64 encoded data, wrapping it into `base64_decode()` breaks the upload.