### PR TITLE
API errors via Guzzle should not throw exception

### DIFF
--- a/src/Core/HttpClients/GuzzleHttpClient.php
+++ b/src/Core/HttpClients/GuzzleHttpClient.php
@@ -41,7 +41,7 @@
         if(isset($guzzleClient)){
             $this->guzzleClient = $guzzleClient;
         }else{
-            $this->guzzleClient = new Client();
+            $this->guzzleClient = new Client(['http_errors' => false]);
         }
      }
 


### PR DESCRIPTION
When using the default cURL subsystem the response is correctly handled by the SDK Fault Handler for clients to consume as documented.
But when using Guzzle subsystem by calling `$dataService->setClientName('guzzle')` it throws an exception by default for all HTTP 4xx and 5xx response codes, the SDK does not process it as a Fault Handler and the client cannot handle cases such as 401 Unauthorized to re-authenticate etc.

Guzzle should be configured to treat HTTP error responses same as all http responses, not throw exception.