### PR TITLE
Add BillPayment on payment classname

### DIFF
--- a/src/Core/CoreConstants.php
+++ b/src/Core/CoreConstants.php
@@ -211,7 +211,7 @@ class CoreConstants
      */
     const Id = "Id";
 
-    const PAYMENTCLASSNAME = ["payment", "salesreceipt"];
+    const PAYMENTCLASSNAME = ["payment", "salesreceipt", "billpayment"];
     const VOID_QUERYPARAMETER_GENERAL = '?operation=void';
     const VOID_QUERYPARAMETER_PAYMENT = '?operation=update&include=void';
 


### PR DESCRIPTION
Void on BillPayment is not working right now. I have found out that it is not using the correct [query parameter](https://github.com/intuit/QuickBooks-V3-PHP-SDK/blob/master/src/DataService/DataService.php#L862). 