### PR TITLE
Fixing Deprecated Warnings for dynamic property

### DIFF
--- a/src/Core/CoreConstants.php
+++ b/src/Core/CoreConstants.php
@@ -297,7 +297,7 @@ class CoreConstants
      * The Request source header value.
      * @var string REQUESTSOURCEHEADER
      */
-    const USERAGENT = "V3PHPSDK6.1.1";
+    const USERAGENT = "V3PHPSDK6.1.2";
 
     public static function getType($string, $return=1)
     {

--- a/src/Diagnostics/LoggerBase.php
+++ b/src/Diagnostics/LoggerBase.php
@@ -2,10 +2,12 @@
 namespace QuickBooksOnline\API\Diagnostics;
 
 use QuickBooksOnline\API\Core\CoreConstants;
+use AllowDynamicProperties;
 
 /**
  * This file contains an interface for Logging.
  */
+#[AllowDynamicProperties]
 class LoggerBase
 {
 

--- a/src/ReportService/ReportService.php
+++ b/src/ReportService/ReportService.php
@@ -1233,13 +1233,13 @@ class ReportService
             array_push($uriParameterList, array("printed", $this->getPrinted()));
         }
         if (!is_null($this->both_amount)) {
-            array_push($uriParameterList, array("both_amount", $this->getBothAmount()));
+            array_push($uriParameterList, array("bothamount", $this->getBothAmount()));
         }
         if (!is_null($this->memo)) {
             array_push($uriParameterList, array("memo", $this->getMemo()));
         }
         if (!is_null($this->doc_num)) {
-            array_push($uriParameterList, array("doc_num", $this->getDocNum()));
+            array_push($uriParameterList, array("docnum", $this->getDocNum()));
         }
         if (!is_null($this->subcol_pct_inc)) {
             array_push($uriParameterList, array("subcol_pct_inc", $this->getPercentIncome()));

--- a/src/XSD2PHP/src/com/mikebevz/xsd2php/Php2Xml.php
+++ b/src/XSD2PHP/src/com/mikebevz/xsd2php/Php2Xml.php
@@ -3,6 +3,7 @@
 namespace QuickBooksOnline\API\XSD2PHP\src\com\mikebevz\xsd2php;
 
 use QuickBooksOnline\API\Core\CoreConstants;
+use AllowDynamicProperties;
 
 /**
  * Copyright 2010 Mike Bevz <myb@mikebevz.com>
@@ -29,6 +30,7 @@ use QuickBooksOnline\API\Core\CoreConstants;
  * @author Mike Bevz <myb@mikebevz.com>
  * @version 0.0.4
  */
+#[AllowDynamicProperties]
 class Php2Xml extends Common
 {
     /**


### PR DESCRIPTION
Fix for https://github.com/intuit/QuickBooks-V3-PHP-SDK/issues/486 and https://github.com/intuit/QuickBooks-V3-PHP-SDK/issues/483
Fix for https://github.com/intuit/QuickBooks-V3-PHP-SDK/issues/489