### PR TITLE
Guzzle client should not throw exceptions upon error by default

### DIFF
--- a/src/Core/HttpClients/GuzzleHttpClient.php
+++ b/src/Core/HttpClients/GuzzleHttpClient.php
@@ -41,7 +41,7 @@
         if(isset($guzzleClient)){
             $this->guzzleClient = $guzzleClient;
         }else{
-            $this->guzzleClient = new Client();
+            $this->guzzleClient = new Client(['http_errors' => false]);
         }
      }
 


### PR DESCRIPTION
Instead it should somehow depend on `DataService::isThrownExceptionOnError()` and not remain default throw exceptions