### PR TITLE
Fix Exception when trying to apply Credit Card Payment to Sales Receipt

### DIFF
--- a/src/Data/IPPSalesReceipt.php
+++ b/src/Data/IPPSalesReceipt.php
@@ -61,6 +61,17 @@ class IPPSalesReceipt
 	 * @var float
 	 */
 	public $LessCIS;
-
+	/**
+     	 * @Definition
+    	   Product: ALL
+    	   Description Information about a credit card payment for the Recipet.
+    	   NotApplicableTo: Estimate, SalesOrder
+	 * @xmlType element
+     	 * @xmlNamespace http://schema.intuit.com/finance/v3
+     	 * @xmlMinOccurs 0
+     	 * @xmlName SalesReceiptCCPayment
+     	 * @var com\intuit\schema\finance\v3\IPPCreditCardPayment
+     	*/
+    	public $SalesReceiptCCPayment;
 
 } // end class IPPSalesReceipt

--- a/src/Facades/FacadeClassMapper.php
+++ b/src/Facades/FacadeClassMapper.php
@@ -192,7 +192,7 @@ class FacadeClassMapper
          //Use JournalEntryEntity to replace Entity
          'JournalEntryEntity' => 'EntityTypeRef',
          'ScheduleInfo' => 'RecurringScheduleInfo',
-         // Sales Recipet mapping
+         // Sales Receipt mapping
          'SalesReceiptCCPayment' => 'CreditCardPayment',
        ];
     }

--- a/src/Facades/FacadeClassMapper.php
+++ b/src/Facades/FacadeClassMapper.php
@@ -191,7 +191,9 @@ class FacadeClassMapper
          'AdjustmentTaxRateList' => 'TaxRateList',
          //Use JournalEntryEntity to replace Entity
          'JournalEntryEntity' => 'EntityTypeRef',
-         'ScheduleInfo' => 'RecurringScheduleInfo'
+         'ScheduleInfo' => 'RecurringScheduleInfo',
+         // Sales Recipet mapping
+         'SalesReceiptCCPayment' => 'CreditCardPayment',
        ];
     }
 


### PR DESCRIPTION
This MR fixes the issue that prevents the CC payment on sale receipt conversion which triggers #275.

Use `SalesReceiptCCPayment` instead of `CreditCardPayment` to avoid the mapping.

To make this work use the following structure:
```php
$salesReceiptObj = SalesReceipt::create([
            "CustomerRef" => [
                "value" => $customerRequestObj->Id,
            ],
            "BillEmail" => [
                "Address" => $billingEmail,
            ],
            "Line" => [[
                "Id" => "1",
                "LineNum" => 1,
                "Description" => "Pest Control Services",
                "Amount" => 35.0,
                "DetailType" => "SalesItemLineDetail",
                "SalesItemLineDetail" => [
                    "ItemRef" => [
                        "value" => "1",
                        "name" => "Pest Control",
                    ],
                    "UnitPrice" => 35,
                    "Qty" => 1,
                    "TaxCodeRef" => [
                        "value" => "NON",
                    ],
                ],
            ]],
            "PaymentType" => "CreditCard",
            "SalesReceiptCCPayment" => [
                "CreditChargeInfo" => [
                    "ProcessPayment" => true,
                ],
                "CreditChargeResponse" => [
                    "CCTransId" => "E2XT5I2FFZGS"
                ]
            ],
            "TxnSource" => "IntuitPayment",
        ]);
```

We avoid the mapping from `CreditCardPayment` to `BillPaymentCreditCard` with this.

We don't know if removing the mapping might affect this, so we added this to conserve backward compatibility.