### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+/docs export-ignore
+/src/_Samples export-ignore
+/src/Utility.Test export-ignore
+/src/XSD2PHP/docs export-ignore
+/src/XSD2PHP/resources export-ignore
+/src/XSD2PHP/test export-ignore
+/src/XSD2PHP/website export-ignore
+/src/XSD2PHP/buildDocs.sh export-ignore
+/test export-ignore
+/views export-ignore
+/.travis.yml export-ignore
+/composer.lock export-ignore
+/phpunit.xml export-ignore


### PR DESCRIPTION
When Composer installs packages from GitHub, it uses zip files created with `git archive`. Adding `export-ignore` attribute to files causes them to be excluded from `git archive`. I've excluded docs, tests, and other files that aren't necessary when installing this package, which reduces package size from ~21MB to ~2.7MB.

You can test this by running the following commands:
```sh
git archive master -o master.zip
git archive replace-with-this-branch-name -o gitattributes.zip
```
Then unzip both archives and compare their size and content.