### PR TITLE
Fix bug parsing response into header and body

### DIFF
--- a/src/Core/HttpClients/CurlHttpClient.php
+++ b/src/Core/HttpClients/CurlHttpClient.php
@@ -118,8 +118,8 @@ class CurlHttpClient implements HttpClientInterface{
      */
     public function setIntuitResponse($response){
         $headerSize = $this->basecURL->getInfo(CURLINFO_HEADER_SIZE);
-        $rawHeaders = mb_substr($response, 0, $headerSize);
-        $rawBody = mb_substr($response, $headerSize);
+        $rawHeaders = substr($response, 0, $headerSize);
+        $rawBody = substr($response, $headerSize);
         $httpStatusCode = $this->basecURL->getInfo(CURLINFO_HTTP_CODE);
         $theIntuitResponse = new IntuitResponse($rawHeaders, $rawBody, $httpStatusCode, true);
         $this->intuitResponse = $theIntuitResponse;

--- a/src/DataService/DataService.php
+++ b/src/DataService/DataService.php
@@ -270,7 +270,22 @@ class DataService
         return $this;
     }
 
-    /**
+    /** (bch36)
+	 * Set a callback function for request and response logs
+	 *
+	 * @param callable $callback     The callback function for receiving request and response logs
+	 *
+	 * @return $this
+	 */
+	public function setLogCallback($callback)
+	{
+		$restHandler = $this->restHandler;
+		$loggerUsedByRestHandler = $restHandler->getRequestLogger();
+		$loggerUsedByRestHandler->setLogCallback($callback);
+		return $this;
+	}
+	
+	/**
      * Set logging for OAuth calls
      *
      * @param Boolean $enableLogs          Turns on logging for OAuthCalls


### PR DESCRIPTION
The response variable may contain binary data, making mb_substr the incorrect function to use. Pre PHP 8.3.2, mb_substr would encounter invalid UTF characters in the binary data and fall back to using substr, but from 8.3.2 on, the behavior of mb_substr has changed to replacing the invalid UTF characters with "?". This results in corrupted binary data.

See issue #522 