### PR TITLE
Add compatability with php8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["api", "http", "rest", "quickbooks", "smallbusiness"],
     "homepage": "http://developer.intuit.com",
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.2.5",
         "ext-mbstring": "*",
         "ext-dom": "*",
         "guzzlehttp/guzzle": "^7.9"

--- a/src/Core/HttpClients/CurlHttpClient.php
+++ b/src/Core/HttpClients/CurlHttpClient.php
@@ -26,9 +26,9 @@ class CurlHttpClient implements HttpClientInterface{
 
     /**
      * The constructor for constructing the cURL http client for making API calls
-     * @param BaseCurl $curl    A predefined BaseCurl instance to be used in this client
+     * @param BaseCurl|null $curl    A predefined BaseCurl instance to be used in this client
      */
-    public function __construct(BaseCurl $curl = null)
+    public function __construct(?BaseCurl $curl = null)
     {
         if(isset($curl)){
               $this->basecURL = $curl;

--- a/src/Core/HttpClients/GuzzleHttpClient.php
+++ b/src/Core/HttpClients/GuzzleHttpClient.php
@@ -35,9 +35,9 @@
 
      /**
       * Constructor for GuzzleHttpClient
-      * @param Client guzzleClient passed to the constructor
+      * @param Client|null guzzleClient passed to the constructor
       */
-     public function __construct(Client $guzzleClient = null){
+     public function __construct(?Client $guzzleClient = null){
         if(isset($guzzleClient)){
             $this->guzzleClient = $guzzleClient;
         }else{

--- a/src/Core/HttpClients/SyncRestHandler.php
+++ b/src/Core/HttpClients/SyncRestHandler.php
@@ -48,9 +48,9 @@ class SyncRestHandler extends RestHandler
     * Initializes a new instance of the SyncRestHandler class.
     *
     * @param ServiceContext   $context    The service context used for the request
-    * @param HttpClientInterface $client  The http client used for the request
+    * @param HttpClientInterface|null $client  The http client used for the request
     */
-    public function __construct($context, HttpClientInterface $client = null)
+    public function __construct($context, ?HttpClientInterface $client = null)
     {
         parent::__construct($context);
         $this->context = $context;

--- a/src/Core/OAuth/OAuth1/OAuth1.php
+++ b/src/Core/OAuth/OAuth1/OAuth1.php
@@ -253,10 +253,10 @@ class OAuth1{
 
   /**
    * Add all OAuth query paraemters to the signature string string
-   * @param Array $queryParameters    The queryParameters to be included
-   * @return Array $queryParameters   The complete query parameters
+   * @param array|null $queryParameters    The queryParameters to be included
+   * @return array $queryParameters   The complete query parameters
    */
-  private function appendOAuthPartsTo(array $queryParameters = null){
+  private function appendOAuthPartsTo(?array $queryParameters = null){
       if($queryParameters == null){
           $queryParameters = array();
       }

--- a/src/Core/OAuth/OAuth2/OAuth2LoginHelper.php
+++ b/src/Core/OAuth/OAuth2/OAuth2LoginHelper.php
@@ -101,9 +101,9 @@ class OAuth2LoginHelper
      * @param String $redirectUri                The redirect URI specified for the App
      * @param String $scope                      The scope of the app
      * @param String $state                      The string to verify the request is not compromised
-     * @param ServiceContext $serviceContext     The serviceContext for the request, only passed for making refresh token API call
+     * @param ServiceContext|null $serviceContext     The serviceContext for the request, only passed for making refresh token API call
      */
-    public function __construct($clientID, $clientSecret, $redirectUri = null, $scope = null, $state = null, ServiceContext $serviceContext = null){
+    public function __construct($clientID, $clientSecret, $redirectUri = null, $scope = null, $state = null, ?ServiceContext $serviceContext = null){
         //used for refresh token
         if(isset($serviceContext)){
             $accessTokenObj =  $serviceContext->requestValidator;

--- a/src/XSD2PHP/lib/ZF/1.10.7/Zend/Exception.php
+++ b/src/XSD2PHP/lib/ZF/1.10.7/Zend/Exception.php
@@ -36,10 +36,10 @@ class Zend_Exception extends Exception
      *
      * @param  string $msg
      * @param  int $code
-     * @param  Exception $previous
+     * @param  Exception|null $previous
      * @return void
      */
-    public function __construct($msg = '', $code = 0, Exception $previous = null)
+    public function __construct($msg = '', $code = 0, ?Exception $previous = null)
     {
         if (version_compare(PHP_VERSION, '5.3.0', '<')) {
             parent::__construct($msg, (int) $code);

--- a/src/XSD2PHP/lib/ZF/1.10.7/Zend/Soap/Server.php
+++ b/src/XSD2PHP/lib/ZF/1.10.7/Zend/Soap/Server.php
@@ -154,10 +154,10 @@ class Zend_Soap_Server implements Zend_Server_Interface
      * options are specified, they are passed on to {@link setOptions()}.
      *
      * @param string $wsdl
-     * @param array $options
+     * @param array|null $options
      * @return void
      */
-    public function __construct($wsdl = null, array $options = null)
+    public function __construct($wsdl = null, ?array $options = null)
     {
         if (!extension_loaded('soap')) {
             require_once 'Zend/Soap/Server/Exception.php';
@@ -948,11 +948,11 @@ class Zend_Soap_Server implements Zend_Server_Interface
      * @param string $errstr
      * @param string $errfile
      * @param int $errline
-     * @param array $errcontext
+     * @param array|null $errcontext
      * @return void
      * @throws SoapFault
      */
-    public function handlePhpErrors($errno, $errstr, $errfile = null, $errline = null, array $errcontext = null)
+    public function handlePhpErrors($errno, $errstr, $errfile = null, $errline = null, ?array $errcontext = null)
     {
         throw $this->fault($errstr, "Receiver");
     }


### PR DESCRIPTION
This change prevents deprecations warnings such the following occurring when running on php 8.4
```
PHP Deprecated:  QuickBooksOnline\API\Core\OAuth\OAuth2\OAuth2LoginHelper::__construct(): Implicitly marking parameter $serviceContext as nullable is deprecated, the explicit nullable type must be used instead
```

This change requires php 7.1, but given that there is a requirement on `guzzlehttp/guzzle` version `^7.9` this implies a minimum version of  php 7.2.5 which I have replicated in `composer.json` to make it clearer