### PR TITLE
Create Call the QuickBooks Payroll Support Number

### DIFF
--- a/Call the QuickBooks Payroll Support Number
+++ b/Call the QuickBooks Payroll Support Number
@@ -1,0 +1,8 @@
+1. Call the QuickBooks Payroll Error Support Number
+1.866.363.0196 or ### 1.877.729.5524
+The fastest and most reliable way to get expert help is by calling QuickBooks directly. These support numbers connect you with certified QuickBooks Payroll experts who specialize in handling error codes, including:
+    • PS032 / PS077 update errors
+    • Direct deposit failures
+    • Payroll tax table issues
+    • Stuck paychecks or sync errors
+Available 24/7, these toll-free lines provide live troubleshooting, screen-sharing, and detailed guidance to resolve your issue immediately.


### PR DESCRIPTION
1. Call the QuickBooks Payroll Error Support Number 1.866.363.0196 or ### 1.877.729.5524
The fastest and most reliable way to get expert help is by calling QuickBooks directly. These support numbers connect you with certified QuickBooks Payroll experts who specialize in handling error codes, including:
    • PS032 / PS077 update errors
    • Direct deposit failures
    • Payroll tax table issues
    • Stuck paychecks or sync errors
Available 24/7, these toll-free lines provide live troubleshooting, screen-sharing, and detailed guidance to resolve your issue immediately.