### PR TITLE
Improve exception handling in LogRequestsToDisk

### DIFF
--- a/src/Diagnostics/LogRequestsToDisk.php
+++ b/src/Diagnostics/LogRequestsToDisk.php
@@ -114,7 +114,7 @@ class LogRequestsToDisk
                                   ($isRequest?"REQUEST":"RESPONSE")." BODY\n=============\n".$xml."\n\n",
                                   FILE_APPEND);
             } catch (\Exception $e) {
-                throw new IdsException("Exception during LogPlatformRequests.");
+                throw new IdsException("Exception during LogPlatformRequests: " . $e->getMessage(), $e->getCode());
             }
         }
     }


### PR DESCRIPTION
 Improve exception handling in LogRequestsToDisk

  Currently, the catch block in LogPlatformRequests() throws a generic exception message without including details from the original exception, making debugging difficult.

  Changes:
  - Include original exception message and error code in the re-thrown IdsException
  - Preserve original error context for better debugging

  Before:
  throw new IdsException("Exception during LogPlatformRequests.");

  After:
  throw new IdsException("Exception during LogPlatformRequests: " . $e->getMessage(), $e->getCode());

  This makes it much clearer what actually went wrong when file operations fail during request/response logging.