### PR TITLE
Add isset check to prevent undefined index when Content-Type header

### DIFF
--- a/src/Core/HttpClients/SyncRestHandler.php
+++ b/src/Core/HttpClients/SyncRestHandler.php
@@ -278,10 +278,10 @@ class SyncRestHandler extends RestHandler
      */
     public function LogAPIResponseToLog($body, $requestUri, $httpHeaders){
       $httpHeaders = array_change_key_case($httpHeaders, CASE_LOWER);
-      if(strcasecmp($httpHeaders[strtolower(CoreConstants::CONTENT_TYPE)], CoreConstants::CONTENTTYPE_APPLICATIONXML) == 0 ||
-          strcasecmp($httpHeaders[strtolower(CoreConstants::CONTENT_TYPE)], CoreConstants::CONTENTTYPE_APPLICATIONXML_WITH_CHARSET) == 0){
+      if((isset($httpHeaders[CoreConstants::CONTENT_TYPE]) && strcasecmp($httpHeaders[CoreConstants::CONTENT_TYPE], CoreConstants::CONTENTTYPE_APPLICATIONXML) == 0) ||
+          (isset($httpHeaders[CoreConstants::CONTENT_TYPE]) && strcasecmp($httpHeaders[CoreConstants::CONTENT_TYPE], CoreConstants::CONTENTTYPE_APPLICATIONXML_WITH_CHARSET) == 0) ) {
              $body = $this->parseStringToDom($body);
-      }
+      } 
 
       $this->RequestLogging->LogPlatformRequests($body, $requestUri, $httpHeaders, false);
     }


### PR DESCRIPTION
I faced an issue where LogAPIResponseToLog() threw "Content-Type on null" and 
null comparison errors because it assumed the Content-Type header was 
always present.

This fix adds an isset() check before accessing the Content-Type key, 
so XML parsing is only attempted when the header exists.

With this change, API response logging no longer breaks when the 
Content-Type header is missing or has unexpected values, making it 
safer and more reliable.