### PR TITLE
DEPRECATED  Function curl_close

### DIFF
--- a/src/Core/HttpClients/BaseCurl.php
+++ b/src/Core/HttpClients/BaseCurl.php
@@ -122,7 +122,9 @@ class BaseCurl{
   */
   public function close()
   {
-      curl_close($this->curl);
+      if (PHP_VERSION_ID < 80000) {
+        curl_close($this->curl);
+      }
       $this->curl = null;
   }
 }


### PR DESCRIPTION
Fix error:
DEPRECATED  Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0 in vendor/quickbooks/v3-php-sdk/src/Core/HttpClients/BaseCurl.php on line 125.