### PR TITLE
Address PHP 8.2 deprecation errors related to dynamic property creation in the SDK

### DIFF
--- a/src/Data/IPPBatchItemRequest.php
+++ b/src/Data/IPPBatchItemRequest.php
@@ -91,6 +91,11 @@ class IPPBatchItemRequest
 	 * @var string
 	 */
 	public $optionsData;
-
-
+    /**
+     * @Definition Specifies whether the operation attribute is specified in the request or not
+     * @xmlType attribute
+     * @xmlName operationSpecified
+     * @var true
+     */
+    public bool $operationSpecified;
 } // end class IPPBatchItemRequest


### PR DESCRIPTION
**Key Changes:**
- Updated IPPBatchItemRequest to explicitly declare all properties, including operationSpecified, to prevent runtime errors in PHP 8.2+.

**Files Changed:**
- src/Data/IPPBatchItemRequest.php